### PR TITLE
feat(ops): expose Prometheus metrics on /metrics endpoint (#12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,7 +771,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -2311,6 +2323,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.13.0",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -2727,7 +2779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2760,6 +2812,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2847,6 +2914,24 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "rayon"
@@ -3159,7 +3244,7 @@ dependencies = [
  "std-next",
  "subtle",
  "sync_wrapper",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tower",
@@ -3481,6 +3566,8 @@ dependencies = [
  "hyper-util",
  "indicatif",
  "md-5 0.10.6",
+ "metrics",
+ "metrics-exporter-prometheus",
  "mime_guess",
  "nix",
  "prost",
@@ -3503,6 +3590,12 @@ dependencies = [
  "tracing-subscriber",
  "walkdir",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -3565,7 +3658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04082e93ed1a06debd9148c928234b46d2cf260bc65f44e1d1d3fa594c5beebc"
 dependencies = [
  "simdutf8",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3671,7 +3764,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3680,11 +3773,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ rand = "0.10"
 reqwest = { version = "0.12", default-features = false }
 toml = "1.0"
 nix = { version = "0.29", default-features = false, features = ["fs"] }
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.16", default-features = false }
 
 [target.'cfg(not(windows))'.dependencies]
 tikv-jemallocator = "0.6"

--- a/src/cli/metrics.rs
+++ b/src/cli/metrics.rs
@@ -1,0 +1,163 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use simple3::storage::Storage;
+
+/// Drop-guard that decrements the active HTTP connections gauge on drop.
+pub struct ConnectionGuard;
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        metrics::gauge!("simple3_connections_active").decrement(1.0);
+    }
+}
+
+/// Update per-bucket storage gauges and zero out gauges for deleted buckets.
+pub fn update_storage_gauges(storage: &Storage, prev_buckets: &mut HashSet<String>) {
+    let Ok(buckets) = storage.list_buckets() else {
+        return;
+    };
+    let current: HashSet<String> = buckets.iter().cloned().collect();
+
+    // Zero out gauges for deleted buckets
+    for removed in prev_buckets.difference(&current) {
+        let b: &str = removed;
+        metrics::gauge!("simple3_segments_total", "bucket" => b.to_owned()).set(0.0);
+        metrics::gauge!("simple3_dead_bytes", "bucket" => b.to_owned()).set(0.0);
+        metrics::gauge!("simple3_dead_space_ratio", "bucket" => b.to_owned()).set(0.0);
+    }
+
+    for name in &buckets {
+        let Some(store) = storage.get_bucket(name).ok().flatten() else {
+            continue;
+        };
+        let Ok(stats) = store.segment_stats() else {
+            continue;
+        };
+        let seg_count = stats.len();
+        let total_dead: u64 = stats.iter().map(|s| s.dead_bytes).sum();
+        let total_size: u64 = stats.iter().map(|s| s.size).sum();
+
+        #[allow(clippy::cast_precision_loss)] // u64 -> f64: gauge values; sub-ULP loss irrelevant for monitoring
+        let ratio = if total_size > 0 {
+            total_dead as f64 / total_size as f64
+        } else {
+            0.0
+        };
+
+        let bucket = name.clone();
+        #[allow(clippy::cast_precision_loss)] // u64/usize -> f64: gauge values; sub-ULP loss irrelevant
+        {
+            metrics::gauge!("simple3_segments_total", "bucket" => bucket.clone())
+                .set(seg_count as f64);
+            metrics::gauge!("simple3_dead_bytes", "bucket" => bucket.clone())
+                .set(total_dead as f64);
+        }
+        metrics::gauge!("simple3_dead_space_ratio", "bucket" => bucket).set(ratio);
+    }
+
+    *prev_buckets = current;
+}
+
+/// Spawn a background task that updates storage gauges every 15 seconds.
+pub fn spawn_metrics_updater(
+    storage: &Arc<Storage>,
+    shutdown_rx: &watch::Receiver<bool>,
+) -> JoinHandle<()> {
+    let storage = Arc::clone(storage);
+    let mut rx = shutdown_rx.clone();
+    tokio::spawn(async move {
+        let mut prev_buckets = HashSet::new();
+        loop {
+            {
+                let s = Arc::clone(&storage);
+                let mut pb = std::mem::take(&mut prev_buckets);
+                let result = tokio::task::spawn_blocking(move || {
+                    update_storage_gauges(&s, &mut pb);
+                    pb
+                })
+                .await;
+                if let Ok(pb) = result {
+                    prev_buckets = pb;
+                }
+            }
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(15)) => {}
+                _ = rx.changed() => break,
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_storage_gauges_sets_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).unwrap();
+        storage.create_bucket("metrics-test").unwrap();
+
+        let mut prev = HashSet::new();
+        update_storage_gauges(&storage, &mut prev);
+
+        assert_eq!(prev.len(), 1);
+        assert!(prev.contains("metrics-test"));
+    }
+
+    #[test]
+    fn test_update_storage_gauges_cleans_deleted_buckets() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).unwrap();
+        storage.create_bucket("alive").unwrap();
+        storage.create_bucket("doomed").unwrap();
+
+        let mut prev = HashSet::new();
+        update_storage_gauges(&storage, &mut prev);
+        assert_eq!(prev.len(), 2);
+
+        // Delete one bucket
+        storage.delete_bucket("doomed").unwrap();
+        update_storage_gauges(&storage, &mut prev);
+
+        // prev_buckets should now only contain "alive"
+        assert_eq!(prev.len(), 1);
+        assert!(prev.contains("alive"));
+        assert!(!prev.contains("doomed"));
+    }
+
+    #[test]
+    fn test_prometheus_render_contains_metrics() {
+        // Build a recorder + handle without installing globally
+        let recorder =
+            metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        // Install so metrics macros work (may fail if another test already installed)
+        let _ = metrics::set_global_recorder(recorder);
+
+        // Record a metric via the facade
+        metrics::histogram!(
+            "simple3_request_duration_seconds",
+            "method" => "S3",
+            "operation" => "PutObject",
+        )
+        .record(0.042);
+
+        metrics::counter!("simple3_bytes_received_total").increment(1024);
+
+        let output = handle.render();
+        assert!(
+            output.contains("simple3_request_duration_seconds"),
+            "render output should contain histogram: {output}"
+        );
+        assert!(
+            output.contains("simple3_bytes_received_total"),
+            "render output should contain counter: {output}"
+        );
+    }
+}

--- a/src/cli/metrics.rs
+++ b/src/cli/metrics.rs
@@ -7,8 +7,15 @@ use tokio::task::JoinHandle;
 
 use simple3::storage::Storage;
 
-/// Drop-guard that decrements the active HTTP connections gauge on drop.
+/// Drop-guard that increments active HTTP connections on creation, decrements on drop.
 pub struct ConnectionGuard;
+
+impl ConnectionGuard {
+    pub fn new() -> Self {
+        metrics::gauge!("simple3_connections_active").increment(1.0);
+        Self
+    }
+}
 
 impl Drop for ConnectionGuard {
     fn drop(&mut self) {
@@ -19,6 +26,7 @@ impl Drop for ConnectionGuard {
 /// Update per-bucket storage gauges and zero out gauges for deleted buckets.
 pub fn update_storage_gauges(storage: &Storage, prev_buckets: &mut HashSet<String>) {
     let Ok(buckets) = storage.list_buckets() else {
+        tracing::warn!("metrics: failed to list buckets for gauge refresh");
         return;
     };
     let current: HashSet<String> = buckets.iter().cloned().collect();
@@ -33,9 +41,11 @@ pub fn update_storage_gauges(storage: &Storage, prev_buckets: &mut HashSet<Strin
 
     for name in &buckets {
         let Some(store) = storage.get_bucket(name).ok().flatten() else {
+            tracing::warn!("metrics: failed to open bucket '{name}' for gauge refresh");
             continue;
         };
         let Ok(stats) = store.segment_stats() else {
+            tracing::warn!("metrics: failed to read segment stats for bucket '{name}'");
             continue;
         };
         let seg_count = stats.len();
@@ -133,12 +143,23 @@ mod tests {
 
     #[test]
     fn test_prometheus_render_contains_metrics() {
-        // Build a recorder + handle without installing globally
+        // Build a recorder + handle. set_global_recorder can only succeed once
+        // per process; if another test installed first, we skip the assertions
+        // since the facade writes to a different recorder and handle.render()
+        // would be empty. This is a limitation of the metrics crate's global
+        // recorder model — the production code calls install_recorder() once
+        // at startup, so there is no real-world risk.
         let recorder =
             metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
-        // Install so metrics macros work (may fail if another test already installed)
-        let _ = metrics::set_global_recorder(recorder);
+        let installed = metrics::set_global_recorder(recorder).is_ok();
+
+        if !installed {
+            // Another test already owns the global recorder; we can only
+            // verify that render() doesn't panic.
+            let _ = handle.render();
+            return;
+        }
 
         // Record a metric via the facade
         metrics::histogram!(

--- a/src/cli/metrics.rs
+++ b/src/cli/metrics.rs
@@ -91,8 +91,9 @@ pub fn spawn_metrics_updater(
                     pb
                 })
                 .await;
-                if let Ok(pb) = result {
-                    prev_buckets = pb;
+                match result {
+                    Ok(pb) => prev_buckets = pb,
+                    Err(e) => tracing::error!("metrics gauge refresh task panicked: {e}"),
                 }
             }
             tokio::select! {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@ use clap::{Parser, Subcommand};
 mod admin_auth;
 mod compact;
 mod health;
+mod metrics;
 pub mod client;
 pub mod config;
 pub mod keys;

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -612,11 +612,11 @@ pub async fn run(
         tokio::select! {
             result = listener.accept() => {
                 let (stream, _addr) = result?;
-                metrics::gauge!("simple3_connections_active").increment(1.0);
+                let conn_guard = ConnectionGuard::new();
                 let svc = service.clone();
                 let mut rx = shutdown_rx.clone();
                 connections.spawn(async move {
-                    let _conn_guard = ConnectionGuard;
+                    let _conn_guard = conn_guard;
                     let io = TokioIo::new(stream);
                     let conn = hyper::server::conn::http1::Builder::new()
                         .serve_connection(io, svc);

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -527,12 +527,13 @@ async fn drain_connections(connections: &mut JoinSet<()>, timeout_secs: u64) {
     }
 }
 
-/// Accept HTTP connections until a shutdown signal is received, then drain in-flight requests.
+/// Accept HTTP connections until a shutdown signal is received.
+/// Returns the in-flight connection set for draining by the caller.
 async fn accept_loop(
     listener: TcpListener,
     service: AdminService,
     shutdown_rx: &watch::Receiver<bool>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<JoinSet<()>> {
     let mut connections: JoinSet<()> = JoinSet::new();
     let mut shutdown_rx_accept = shutdown_rx.clone();
 
@@ -569,8 +570,7 @@ async fn accept_loop(
     }
 
     drop(listener);
-    drain_connections(&mut connections, 30).await;
-    Ok(())
+    Ok(connections)
 }
 
 #[allow(clippy::too_many_arguments)] // server config values passed through
@@ -650,9 +650,12 @@ pub async fn run(
     let listener = TcpListener::bind((host, port)).await?;
     tracing::info!("S3 HTTP listening on {}:{}", host, port);
 
-    accept_loop(listener, service, &shutdown_rx).await?;
+    let mut connections = accept_loop(listener, service, &shutdown_rx).await?;
 
-    await_bg_tasks(&mut bg_tasks, shutdown_timeout).await;
+    tokio::join!(
+        drain_connections(&mut connections, shutdown_timeout),
+        await_bg_tasks(&mut bg_tasks, shutdown_timeout),
+    );
 
     match tokio::task::spawn_blocking(move || storage.sync_all()).await {
         Ok(Ok(())) => {}

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -186,7 +186,12 @@ pub fn json_response(status: u16, body: &impl Serialize) -> s3s::HttpResponse {
         .status(status)
         .header("content-type", "application/json")
         .body(s3s::Body::from(json))
-        .unwrap()
+        .unwrap_or_else(|e| {
+            hyper::Response::builder()
+                .status(500)
+                .body(s3s::Body::from(format!(r#"{{"error":"{e}"}}"#)))
+                .expect("fallback response with no custom headers cannot fail")
+        })
 }
 
 fn stats_to_json(stats: &[simple3::storage::SegmentStat]) -> Vec<SegmentStatJson> {

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -126,6 +126,7 @@ struct AdminService {
     storage: Arc<Storage>,
     auth_store: Arc<AuthStore>,
     min_disk_free_mb: u64,
+    prometheus_handle: metrics_exporter_prometheus::PrometheusHandle,
 }
 
 type ServiceFuture =
@@ -138,7 +139,16 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
 
     fn call(&self, req: hyper::Request<hyper::body::Incoming>) -> Self::Future {
         let path = req.uri().path().to_owned();
-        if *req.method() == hyper::Method::GET && path == "/health" {
+        if *req.method() == hyper::Method::GET && path == "/metrics" {
+            let body = self.prometheus_handle.render();
+            Box::pin(async move {
+                Ok(hyper::Response::builder()
+                    .status(200)
+                    .header("content-type", "text/plain; version=0.0.4; charset=utf-8")
+                    .body(s3s::Body::from(body))
+                    .expect("valid response"))
+            })
+        } else if *req.method() == hyper::Method::GET && path == "/health" {
             Box::pin(async {
                 Ok(json_response(200, &serde_json::json!({"status": "ok"})))
             })
@@ -365,6 +375,14 @@ impl Drop for CompactingGuard<'_> {
     }
 }
 
+struct ConnectionGuard;
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        metrics::gauge!("simple3_connections_active").decrement(1.0);
+    }
+}
+
 fn spawn_signal_handler(
     mut sigterm: tokio::signal::unix::Signal,
     mut sigint: tokio::signal::unix::Signal,
@@ -444,6 +462,84 @@ fn spawn_scrub(
     handle
 }
 
+fn update_storage_gauges(
+    storage: &Storage,
+    prev_buckets: &mut std::collections::HashSet<String>,
+) {
+    let Ok(buckets) = storage.list_buckets() else {
+        return;
+    };
+    let current: std::collections::HashSet<String> = buckets.iter().cloned().collect();
+
+    // Zero out gauges for deleted buckets
+    for removed in prev_buckets.difference(&current) {
+        let b = removed.clone();
+        metrics::gauge!("simple3_segments_total", "bucket" => b.clone()).set(0.0);
+        metrics::gauge!("simple3_dead_bytes", "bucket" => b.clone()).set(0.0);
+        metrics::gauge!("simple3_dead_space_ratio", "bucket" => b).set(0.0);
+    }
+
+    for name in &buckets {
+        let Some(store) = storage.get_bucket(name).ok().flatten() else {
+            continue;
+        };
+        let Ok(stats) = store.segment_stats() else {
+            continue;
+        };
+        let seg_count = stats.len();
+        let total_dead: u64 = stats.iter().map(|s| s.dead_bytes).sum();
+        let total_size: u64 = stats.iter().map(|s| s.size).sum();
+
+        #[allow(clippy::cast_precision_loss)] // u64 -> f64: gauge values; sub-ULP loss irrelevant for monitoring
+        let ratio = if total_size > 0 {
+            total_dead as f64 / total_size as f64
+        } else {
+            0.0
+        };
+
+        let bucket = name.clone();
+        #[allow(clippy::cast_precision_loss)] // u64/usize -> f64: gauge values; sub-ULP loss irrelevant
+        {
+            metrics::gauge!("simple3_segments_total", "bucket" => bucket.clone())
+                .set(seg_count as f64);
+            metrics::gauge!("simple3_dead_bytes", "bucket" => bucket.clone())
+                .set(total_dead as f64);
+        }
+        metrics::gauge!("simple3_dead_space_ratio", "bucket" => bucket).set(ratio);
+    }
+
+    *prev_buckets = current;
+}
+
+fn spawn_metrics_updater(
+    storage: &Arc<Storage>,
+    shutdown_rx: &watch::Receiver<bool>,
+) -> JoinHandle<()> {
+    let storage = Arc::clone(storage);
+    let mut rx = shutdown_rx.clone();
+    tokio::spawn(async move {
+        let mut prev_buckets = std::collections::HashSet::new();
+        loop {
+            {
+                let s = Arc::clone(&storage);
+                let mut pb = std::mem::take(&mut prev_buckets);
+                let result = tokio::task::spawn_blocking(move || {
+                    update_storage_gauges(&s, &mut pb);
+                    pb
+                })
+                .await;
+                if let Ok(pb) = result {
+                    prev_buckets = pb;
+                }
+            }
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(15)) => {}
+                _ = rx.changed() => break,
+            }
+        }
+    })
+}
+
 async fn spawn_grpc(
     storage: &Arc<Storage>,
     auth_store: &Arc<AuthStore>,
@@ -513,7 +609,8 @@ async fn drain_connections(connections: &mut JoinSet<()>, timeout_secs: u64) {
     }
 }
 
-#[allow(clippy::too_many_arguments)] // server config values passed through; a struct would add indirection without benefit
+#[allow(clippy::too_many_arguments)] // server config values passed through
+#[allow(clippy::too_many_lines)] // sequential setup (storage, auth, signals, prometheus, listener) resists splitting
 pub async fn run(
     data_dir: &Path,
     host: &str,
@@ -563,6 +660,12 @@ pub async fn run(
         bg_tasks.push(spawn_scrub(&storage, scrub_interval, &shutdown_rx));
     }
 
+    let prometheus_handle = metrics_exporter_prometheus::PrometheusBuilder::new()
+        .install_recorder()
+        .map_err(|e| anyhow::anyhow!("prometheus recorder: {e}"))?;
+
+    bg_tasks.push(spawn_metrics_updater(&storage, &shutdown_rx));
+
     let auth_provider = AuthProvider::new(Arc::clone(&auth_store));
     let mut builder = S3ServiceBuilder::new(s3);
     builder.set_auth(auth_provider.clone());
@@ -574,6 +677,7 @@ pub async fn run(
         storage: Arc::clone(&storage),
         auth_store: Arc::clone(&auth_store),
         min_disk_free_mb,
+        prometheus_handle,
     };
 
     if grpc_port > 0 {
@@ -590,9 +694,11 @@ pub async fn run(
         tokio::select! {
             result = listener.accept() => {
                 let (stream, _addr) = result?;
+                metrics::gauge!("simple3_connections_active").increment(1.0);
                 let svc = service.clone();
                 let mut rx = shutdown_rx.clone();
                 connections.spawn(async move {
+                    let _conn_guard = ConnectionGuard;
                     let io = TokioIo::new(stream);
                     let conn = hyper::server::conn::http1::Builder::new()
                         .serve_connection(io, svc);
@@ -691,5 +797,69 @@ mod tests {
         assert!(storage.is_compacting());
         storage.end_compacting();
         assert!(!storage.is_compacting());
+    }
+
+    #[test]
+    fn test_update_storage_gauges_sets_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).unwrap();
+        storage.create_bucket("metrics-test").unwrap();
+
+        let mut prev = std::collections::HashSet::new();
+        update_storage_gauges(&storage, &mut prev);
+
+        assert_eq!(prev.len(), 1);
+        assert!(prev.contains("metrics-test"));
+    }
+
+    #[test]
+    fn test_update_storage_gauges_cleans_deleted_buckets() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).unwrap();
+        storage.create_bucket("alive").unwrap();
+        storage.create_bucket("doomed").unwrap();
+
+        let mut prev = std::collections::HashSet::new();
+        update_storage_gauges(&storage, &mut prev);
+        assert_eq!(prev.len(), 2);
+
+        // Delete one bucket
+        storage.delete_bucket("doomed").unwrap();
+        update_storage_gauges(&storage, &mut prev);
+
+        // prev_buckets should now only contain "alive"
+        assert_eq!(prev.len(), 1);
+        assert!(prev.contains("alive"));
+        assert!(!prev.contains("doomed"));
+    }
+
+    #[test]
+    fn test_prometheus_render_contains_metrics() {
+        // Build a recorder + handle without installing globally
+        let recorder =
+            metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        // Install so metrics macros work (may fail if another test already installed)
+        let _ = metrics::set_global_recorder(recorder);
+
+        // Record a metric via the facade
+        metrics::histogram!(
+            "simple3_request_duration_seconds",
+            "method" => "S3",
+            "operation" => "PutObject",
+        )
+        .record(0.042);
+
+        metrics::counter!("simple3_bytes_received_total").increment(1024);
+
+        let output = handle.render();
+        assert!(
+            output.contains("simple3_request_duration_seconds"),
+            "render output should contain histogram: {output}"
+        );
+        assert!(
+            output.contains("simple3_bytes_received_total"),
+            "render output should contain counter: {output}"
+        );
     }
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -146,7 +146,9 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
                     .status(200)
                     .header("content-type", "text/plain; version=0.0.4; charset=utf-8")
                     .body(s3s::Body::from(body))
-                    .expect("valid response"))
+                    .unwrap_or_else(|e| {
+                        json_response(500, &serde_json::json!({"error": format!("metrics render: {e}")}))
+                    }))
             })
         } else if *req.method() == hyper::Method::GET && path == "/health" {
             Box::pin(async {
@@ -375,13 +377,7 @@ impl Drop for CompactingGuard<'_> {
     }
 }
 
-struct ConnectionGuard;
-
-impl Drop for ConnectionGuard {
-    fn drop(&mut self) {
-        metrics::gauge!("simple3_connections_active").decrement(1.0);
-    }
-}
+use super::metrics::{ConnectionGuard, spawn_metrics_updater};
 
 fn spawn_signal_handler(
     mut sigterm: tokio::signal::unix::Signal,
@@ -462,84 +458,6 @@ fn spawn_scrub(
     handle
 }
 
-fn update_storage_gauges(
-    storage: &Storage,
-    prev_buckets: &mut std::collections::HashSet<String>,
-) {
-    let Ok(buckets) = storage.list_buckets() else {
-        return;
-    };
-    let current: std::collections::HashSet<String> = buckets.iter().cloned().collect();
-
-    // Zero out gauges for deleted buckets
-    for removed in prev_buckets.difference(&current) {
-        let b = removed.clone();
-        metrics::gauge!("simple3_segments_total", "bucket" => b.clone()).set(0.0);
-        metrics::gauge!("simple3_dead_bytes", "bucket" => b.clone()).set(0.0);
-        metrics::gauge!("simple3_dead_space_ratio", "bucket" => b).set(0.0);
-    }
-
-    for name in &buckets {
-        let Some(store) = storage.get_bucket(name).ok().flatten() else {
-            continue;
-        };
-        let Ok(stats) = store.segment_stats() else {
-            continue;
-        };
-        let seg_count = stats.len();
-        let total_dead: u64 = stats.iter().map(|s| s.dead_bytes).sum();
-        let total_size: u64 = stats.iter().map(|s| s.size).sum();
-
-        #[allow(clippy::cast_precision_loss)] // u64 -> f64: gauge values; sub-ULP loss irrelevant for monitoring
-        let ratio = if total_size > 0 {
-            total_dead as f64 / total_size as f64
-        } else {
-            0.0
-        };
-
-        let bucket = name.clone();
-        #[allow(clippy::cast_precision_loss)] // u64/usize -> f64: gauge values; sub-ULP loss irrelevant
-        {
-            metrics::gauge!("simple3_segments_total", "bucket" => bucket.clone())
-                .set(seg_count as f64);
-            metrics::gauge!("simple3_dead_bytes", "bucket" => bucket.clone())
-                .set(total_dead as f64);
-        }
-        metrics::gauge!("simple3_dead_space_ratio", "bucket" => bucket).set(ratio);
-    }
-
-    *prev_buckets = current;
-}
-
-fn spawn_metrics_updater(
-    storage: &Arc<Storage>,
-    shutdown_rx: &watch::Receiver<bool>,
-) -> JoinHandle<()> {
-    let storage = Arc::clone(storage);
-    let mut rx = shutdown_rx.clone();
-    tokio::spawn(async move {
-        let mut prev_buckets = std::collections::HashSet::new();
-        loop {
-            {
-                let s = Arc::clone(&storage);
-                let mut pb = std::mem::take(&mut prev_buckets);
-                let result = tokio::task::spawn_blocking(move || {
-                    update_storage_gauges(&s, &mut pb);
-                    pb
-                })
-                .await;
-                if let Ok(pb) = result {
-                    prev_buckets = pb;
-                }
-            }
-            tokio::select! {
-                () = tokio::time::sleep(Duration::from_secs(15)) => {}
-                _ = rx.changed() => break,
-            }
-        }
-    })
-}
-
 async fn spawn_grpc(
     storage: &Arc<Storage>,
     auth_store: &Arc<AuthStore>,
@@ -610,7 +528,7 @@ async fn drain_connections(connections: &mut JoinSet<()>, timeout_secs: u64) {
 }
 
 #[allow(clippy::too_many_arguments)] // server config values passed through
-#[allow(clippy::too_many_lines)] // sequential setup (storage, auth, signals, prometheus, listener) resists splitting
+#[allow(clippy::too_many_lines)] // sequential server setup (storage, auth, signals, prometheus, listener)
 pub async fn run(
     data_dir: &Path,
     host: &str,
@@ -799,67 +717,4 @@ mod tests {
         assert!(!storage.is_compacting());
     }
 
-    #[test]
-    fn test_update_storage_gauges_sets_values() {
-        let dir = tempfile::tempdir().unwrap();
-        let storage = Storage::open(dir.path()).unwrap();
-        storage.create_bucket("metrics-test").unwrap();
-
-        let mut prev = std::collections::HashSet::new();
-        update_storage_gauges(&storage, &mut prev);
-
-        assert_eq!(prev.len(), 1);
-        assert!(prev.contains("metrics-test"));
-    }
-
-    #[test]
-    fn test_update_storage_gauges_cleans_deleted_buckets() {
-        let dir = tempfile::tempdir().unwrap();
-        let storage = Storage::open(dir.path()).unwrap();
-        storage.create_bucket("alive").unwrap();
-        storage.create_bucket("doomed").unwrap();
-
-        let mut prev = std::collections::HashSet::new();
-        update_storage_gauges(&storage, &mut prev);
-        assert_eq!(prev.len(), 2);
-
-        // Delete one bucket
-        storage.delete_bucket("doomed").unwrap();
-        update_storage_gauges(&storage, &mut prev);
-
-        // prev_buckets should now only contain "alive"
-        assert_eq!(prev.len(), 1);
-        assert!(prev.contains("alive"));
-        assert!(!prev.contains("doomed"));
-    }
-
-    #[test]
-    fn test_prometheus_render_contains_metrics() {
-        // Build a recorder + handle without installing globally
-        let recorder =
-            metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
-        let handle = recorder.handle();
-        // Install so metrics macros work (may fail if another test already installed)
-        let _ = metrics::set_global_recorder(recorder);
-
-        // Record a metric via the facade
-        metrics::histogram!(
-            "simple3_request_duration_seconds",
-            "method" => "S3",
-            "operation" => "PutObject",
-        )
-        .record(0.042);
-
-        metrics::counter!("simple3_bytes_received_total").increment(1024);
-
-        let output = handle.render();
-        assert!(
-            output.contains("simple3_request_duration_seconds"),
-            "render output should contain histogram: {output}"
-        );
-        assert!(
-            output.contains("simple3_bytes_received_total"),
-            "render output should contain counter: {output}"
-        );
-    }
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -527,8 +527,53 @@ async fn drain_connections(connections: &mut JoinSet<()>, timeout_secs: u64) {
     }
 }
 
+/// Accept HTTP connections until a shutdown signal is received, then drain in-flight requests.
+async fn accept_loop(
+    listener: TcpListener,
+    service: AdminService,
+    shutdown_rx: &watch::Receiver<bool>,
+) -> anyhow::Result<()> {
+    let mut connections: JoinSet<()> = JoinSet::new();
+    let mut shutdown_rx_accept = shutdown_rx.clone();
+
+    loop {
+        tokio::select! {
+            result = listener.accept() => {
+                let (stream, _addr) = result?;
+                let conn_guard = ConnectionGuard::new();
+                let svc = service.clone();
+                let mut rx = shutdown_rx.clone();
+                connections.spawn(async move {
+                    let _conn_guard = conn_guard;
+                    let io = TokioIo::new(stream);
+                    let conn = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(io, svc);
+                    tokio::pin!(conn);
+                    tokio::select! {
+                        result = conn.as_mut() => {
+                            if let Err(e) = result {
+                                tracing::error!("connection error: {e}");
+                            }
+                        }
+                        _ = rx.changed() => {
+                            conn.as_mut().graceful_shutdown();
+                            if let Err(e) = conn.await {
+                                tracing::error!("connection error during drain: {e}");
+                            }
+                        }
+                    }
+                });
+            }
+            _ = shutdown_rx_accept.changed() => break,
+        }
+    }
+
+    drop(listener);
+    drain_connections(&mut connections, 30).await;
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)] // server config values passed through
-#[allow(clippy::too_many_lines)] // sequential server setup (storage, auth, signals, prometheus, listener)
 pub async fn run(
     data_dir: &Path,
     host: &str,
@@ -605,46 +650,9 @@ pub async fn run(
     let listener = TcpListener::bind((host, port)).await?;
     tracing::info!("S3 HTTP listening on {}:{}", host, port);
 
-    let mut connections: JoinSet<()> = JoinSet::new();
-    let mut shutdown_rx_accept = shutdown_rx.clone();
+    accept_loop(listener, service, &shutdown_rx).await?;
 
-    loop {
-        tokio::select! {
-            result = listener.accept() => {
-                let (stream, _addr) = result?;
-                let conn_guard = ConnectionGuard::new();
-                let svc = service.clone();
-                let mut rx = shutdown_rx.clone();
-                connections.spawn(async move {
-                    let _conn_guard = conn_guard;
-                    let io = TokioIo::new(stream);
-                    let conn = hyper::server::conn::http1::Builder::new()
-                        .serve_connection(io, svc);
-                    tokio::pin!(conn);
-                    tokio::select! {
-                        result = conn.as_mut() => {
-                            if let Err(e) = result {
-                                tracing::error!("connection error: {e}");
-                            }
-                        }
-                        _ = rx.changed() => {
-                            conn.as_mut().graceful_shutdown();
-                            if let Err(e) = conn.await {
-                                tracing::error!("connection error during drain: {e}");
-                            }
-                        }
-                    }
-                });
-            }
-            _ = shutdown_rx_accept.changed() => break,
-        }
-    }
-
-    drop(listener);
-    tokio::join!(
-        drain_connections(&mut connections, shutdown_timeout),
-        await_bg_tasks(&mut bg_tasks, shutdown_timeout),
-    );
+    await_bg_tasks(&mut bg_tasks, shutdown_timeout).await;
 
     match tokio::task::spawn_blocking(move || storage.sync_all()).await {
         Ok(Ok(())) => {}

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -10,6 +10,7 @@ use crate::auth::grpc_auth::{
     check_grpc_access, extract_credentials, extract_credentials_from_metadata,
 };
 use crate::auth::AuthStore;
+use crate::metrics_util::DurationRecorder;
 use crate::grpc_helpers::{
     bulk_get_header, bulk_get_not_found, bulk_put_one_object, map_io_err, meta_to_proto,
     segments_to_proto, spawn_download_stream, stream_to_tmp, TMP_COUNTER,
@@ -96,6 +97,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<Streaming<PutObjectRequest>>,
     ) -> Result<Response<PutObjectResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "PutObject");
         let (metadata, _, stream) = request.into_parts();
         let mut stream = stream;
 
@@ -156,6 +158,8 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<GetObjectRequest>,
     ) -> Result<Response<Self::GetObjectStream>, Status> {
+        // Timer measures time-to-first-byte; data streams asynchronously after return.
+        let _timer = DurationRecorder::new("gRPC", "GetObject");
         let input = request.get_ref();
         let resource = format!("arn:s3:::{}/{}", input.bucket, input.key);
         let action = if input.version_id.is_some() {
@@ -213,6 +217,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<HeadObjectRequest>,
     ) -> Result<Response<HeadObjectResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "HeadObject");
         let input = request.get_ref();
         let resource = format!("arn:s3:::{}/{}", input.bucket, input.key);
         let action = if input.version_id.is_some() {
@@ -248,6 +253,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<DeleteObjectRequest>,
     ) -> Result<Response<DeleteObjectResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "DeleteObject");
         let input = request.get_ref();
         let resource = format!("arn:s3:::{}/{}", input.bucket, input.key);
         let action = if input.version_id.is_some() {
@@ -301,6 +307,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<DeleteObjectsRequest>,
     ) -> Result<Response<DeleteObjectsResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "DeleteObjects");
         // Per-item auth: version-specific deletes require s3:DeleteObjectVersion
         let bucket = &request.get_ref().bucket;
         for item in &request.get_ref().items {
@@ -367,6 +374,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<CopyObjectRequest>,
     ) -> Result<Response<CopyObjectResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "CopyObject");
         let input = request.get_ref();
         let src_resource = format!("arn:s3:::{}/{}", input.source_bucket, input.source_key);
         let dest_resource = format!("arn:s3:::{}/{}", input.dest_bucket, input.dest_key);
@@ -437,6 +445,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<ListObjectsRequest>,
     ) -> Result<Response<ListObjectsResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "ListObjects");
         let resource = format!("arn:s3:::{}", request.get_ref().bucket);
         self.check_auth(&request, "s3:ListBucket", &resource)?;
         let input = request.into_inner();
@@ -511,6 +520,8 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<BulkGetRequest>,
     ) -> Result<Response<Self::BulkGetStream>, Status> {
+        // Timer measures time-to-first-byte; data streams asynchronously after return.
+        let _timer = DurationRecorder::new("gRPC", "BulkGet");
         let resource = format!("arn:s3:::{}/*", request.get_ref().bucket);
         self.check_auth(&request, "s3:GetObject", &resource)?;
         let input = request.into_inner();
@@ -563,6 +574,8 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<Streaming<BulkPutRequest>>,
     ) -> Result<Response<Self::BulkPutStream>, Status> {
+        // Timer measures time-to-first-byte; stream consumed asynchronously after return.
+        let _timer = DurationRecorder::new("gRPC", "BulkPut");
         // For bulk_put we check auth at the request level with a wildcard resource
         // since we don't know buckets/keys until we read the stream
         let (metadata, _, stream) = request.into_parts();
@@ -638,6 +651,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<HeadBucketRequest>,
     ) -> Result<Response<HeadBucketResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "HeadBucket");
         let resource = format!("arn:s3:::{}", request.get_ref().name);
         self.check_auth(&request, "s3:HeadBucket", &resource)?;
         let name = request.into_inner().name;
@@ -649,6 +663,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<CreateBucketRequest>,
     ) -> Result<Response<CreateBucketResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "CreateBucket");
         let resource = format!("arn:s3:::{}", request.get_ref().name);
         self.check_auth(&request, "s3:CreateBucket", &resource)?;
         let name = request.into_inner().name;
@@ -667,6 +682,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<DeleteBucketRequest>,
     ) -> Result<Response<DeleteBucketResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "DeleteBucket");
         let resource = format!("arn:s3:::{}", request.get_ref().name);
         self.check_auth(&request, "s3:DeleteBucket", &resource)?;
         let name = request.into_inner().name;
@@ -698,6 +714,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<ListBucketsRequest>,
     ) -> Result<Response<ListBucketsResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "ListBuckets");
         self.check_auth(&request, "s3:ListAllMyBuckets", "arn:s3:::*")?;
         let storage = Arc::clone(&self.storage);
         let buckets = tokio::task::spawn_blocking(move || storage.list_buckets())
@@ -716,6 +733,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<GetBucketVersioningRequest>,
     ) -> Result<Response<GetBucketVersioningResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "GetBucketVersioning");
         let resource = format!("arn:s3:::{}", request.get_ref().bucket);
         self.check_auth(&request, "s3:GetBucketVersioning", &resource)?;
         let input = request.into_inner();
@@ -739,6 +757,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<PutBucketVersioningRequest>,
     ) -> Result<Response<PutBucketVersioningResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "PutBucketVersioning");
         let resource = format!("arn:s3:::{}", request.get_ref().bucket);
         self.check_auth(&request, "s3:PutBucketVersioning", &resource)?;
         let input = request.into_inner();
@@ -766,6 +785,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<ListObjectVersionsRequest>,
     ) -> Result<Response<ListObjectVersionsResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "ListObjectVersions");
         let resource = format!("arn:s3:::{}", request.get_ref().bucket);
         self.check_auth(&request, "s3:ListBucketVersions", &resource)?;
         let input = request.into_inner();
@@ -855,6 +875,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<StatsRequest>,
     ) -> Result<Response<StatsResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "Stats");
         let resource = format!("arn:s3:::{}", request.get_ref().bucket);
         self.check_auth(&request, "admin:Stats", &resource)?;
         let bucket = request.into_inner().bucket;
@@ -889,6 +910,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<CompactRequest>,
     ) -> Result<Response<CompactResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "Compact");
         let resource = format!("arn:s3:::{}", request.get_ref().bucket);
         self.check_auth(&request, "admin:Compact", &resource)?;
         let bucket = request.into_inner().bucket;
@@ -923,6 +945,7 @@ impl Simple3 for GrpcService {
         &self,
         request: Request<VerifyRequest>,
     ) -> Result<Response<VerifyResponse>, Status> {
+        let _timer = DurationRecorder::new("gRPC", "Verify");
         let resource = format!("arn:s3:::{}", request.get_ref().bucket);
         self.check_auth(&request, "admin:Verify", &resource)?;
         let bucket = request.into_inner().bucket;

--- a/src/grpc_helpers.rs
+++ b/src/grpc_helpers.rs
@@ -84,6 +84,8 @@ pub async fn stream_to_tmp(
     file.flush()
         .map_err(|e| Status::internal(format!("flush tmp: {e}")))?;
 
+    metrics::counter!("simple3_bytes_received_total").increment(size);
+
     let etag = format!("{:x}", hasher.finalize());
     Ok((etag, size, crc))
 }
@@ -110,6 +112,7 @@ pub fn spawn_download_stream(
 
             match data {
                 Ok(bytes) => {
+                    metrics::counter!("simple3_bytes_sent_total").increment(bytes.len() as u64);
                     let resp = GetObjectResponse {
                         response: Some(proto::get_object_response::Response::Data(bytes)),
                     };
@@ -145,6 +148,7 @@ pub async fn stream_object_chunks(
 
         match data {
             Ok(Ok(bytes)) => {
+                metrics::counter!("simple3_bytes_sent_total").increment(bytes.len() as u64);
                 let resp = BulkGetResponse {
                     response: Some(proto::bulk_get_response::Response::Data(bytes)),
                 };
@@ -238,6 +242,8 @@ pub async fn bulk_put_one_object(
     .await
     .map_err(|e| Status::internal(format!("task panicked: {e}")))?
     .map_err(map_io_err)?;
+
+    metrics::counter!("simple3_bytes_received_total").increment(size);
 
     let content_md5 = meta.content_md5.unwrap_or_default();
     Ok((etag, content_md5, size))

--- a/src/grpc_helpers.rs
+++ b/src/grpc_helpers.rs
@@ -236,14 +236,14 @@ pub async fn bulk_put_one_object(
     let metadata = init.user_metadata.clone();
     let s = Arc::clone(store);
 
+    metrics::counter!("simple3_bytes_received_total").increment(size);
+
     let meta = tokio::task::spawn_blocking(move || {
         s.put_object_streamed(&key, &tmp_path, content_type, etag_clone, now, metadata, Some(crc))
     })
     .await
     .map_err(|e| Status::internal(format!("task panicked: {e}")))?
     .map_err(map_io_err)?;
-
-    metrics::counter!("simple3_bytes_received_total").increment(size);
 
     let content_md5 = meta.content_md5.unwrap_or_default();
     Ok((etag, content_md5, size))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod grpc;
 pub mod grpc_helpers;
+pub mod metrics_util;
 pub mod s3impl;
 pub mod storage;
 pub mod types;

--- a/src/metrics_util.rs
+++ b/src/metrics_util.rs
@@ -1,0 +1,68 @@
+use std::time::Instant;
+
+/// Drop-guard that records request duration on completion.
+///
+/// For streaming gRPC RPCs (`GetObject`, `BulkGet`, `BulkPut`) the timer measures
+/// time-to-first-byte (handler setup), not full transfer duration, because the
+/// guard is dropped when the handler returns a `Response<Stream>` before data
+/// flows. Upload-direction RPCs (`PutObject`) fully consume the stream before
+/// returning, so their duration is accurate end-to-end.
+pub struct DurationRecorder {
+    method: &'static str,
+    operation: &'static str,
+    start: Instant,
+}
+
+impl DurationRecorder {
+    pub fn new(method: &'static str, operation: &'static str) -> Self {
+        Self {
+            method,
+            operation,
+            start: Instant::now(),
+        }
+    }
+}
+
+impl Drop for DurationRecorder {
+    fn drop(&mut self) {
+        metrics::histogram!(
+            "simple3_request_duration_seconds",
+            "method" => self.method,
+            "operation" => self.operation,
+        )
+        .record(self.start.elapsed().as_secs_f64());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_recorder_records_on_drop() {
+        // Install a no-op recorder so the macro doesn't panic
+        let recorder = metrics::NoopRecorder;
+        let _ = metrics::set_global_recorder(recorder);
+
+        let timer = DurationRecorder::new("S3", "PutObject");
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let elapsed = timer.start.elapsed();
+        drop(timer);
+        // Verify at least 5ms elapsed (timer was live)
+        assert!(elapsed.as_millis() >= 5);
+    }
+
+    #[test]
+    fn duration_recorder_works_on_error_path() {
+        let recorder = metrics::NoopRecorder;
+        let _ = metrics::set_global_recorder(recorder);
+
+        // Simulate an error path: timer dropped before function returns Ok
+        let result: Result<(), &str> = {
+            let _timer = DurationRecorder::new("gRPC", "GetObject");
+            Err("simulated error")
+        };
+        // Timer dropped here — should not panic even on error path
+        assert!(result.is_err());
+    }
+}

--- a/src/s3impl.rs
+++ b/src/s3impl.rs
@@ -24,6 +24,7 @@ use s3s::dto::{
 };
 use s3s::{s3_error, S3Request, S3Response, S3Result, S3};
 
+use crate::metrics_util::DurationRecorder;
 use crate::storage::versioning::VersioningState;
 use crate::storage::{BucketStore, Storage};
 use crate::types::ObjectMeta;
@@ -66,6 +67,7 @@ async fn stream_body_to_tmp(body: StreamingBlob, tmp_path: &Path) -> S3Result<(S
     let mut writer = io::BufWriter::with_capacity(1024 * 1024, file);
     let mut hasher = Md5::new();
     let mut crc: u32 = 0;
+    let mut total_bytes = 0u64;
     let mut stream = body;
 
     while let Some(chunk) = stream.try_next().await.map_err(|e| { tracing::error!("read request body: {e}"); s3_error!(InternalError) })? {
@@ -74,9 +76,11 @@ async fn stream_body_to_tmp(body: StreamingBlob, tmp_path: &Path) -> S3Result<(S
             .map_err(|e| { tracing::error!("write tmp file: {e}"); s3_error!(e, InternalError) })?;
         hasher.update(&chunk);
         crc = crc32c::crc32c_append(crc, &chunk);
+        total_bytes += chunk.len() as u64;
     }
     writer.flush().map_err(|e| { tracing::error!("flush tmp file: {e}"); s3_error!(e, InternalError) })?;
 
+    metrics::counter!("simple3_bytes_received_total").increment(total_bytes);
     Ok((format!("{:x}", hasher.finalize()), crc))
 }
 
@@ -110,6 +114,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<HeadBucketInput>,
     ) -> S3Result<S3Response<HeadBucketOutput>> {
+        let _timer = DurationRecorder::new("S3", "HeadBucket");
         let bucket = req.input.bucket;
         let _store = self.bucket(&bucket)?;
         Ok(S3Response::new(HeadBucketOutput::default()))
@@ -119,6 +124,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<CreateBucketInput>,
     ) -> S3Result<S3Response<CreateBucketOutput>> {
+        let _timer = DurationRecorder::new("S3", "CreateBucket");
         let bucket = req.input.bucket;
         let storage = Arc::clone(&self.inner);
         let existed = blocking(move || storage.create_bucket(&bucket))
@@ -134,6 +140,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<DeleteBucketInput>,
     ) -> S3Result<S3Response<DeleteBucketOutput>> {
+        let _timer = DurationRecorder::new("S3", "DeleteBucket");
         let bucket = req.input.bucket;
         let store = self.bucket(&bucket)?;
         let storage = Arc::clone(&self.inner);
@@ -162,6 +169,7 @@ impl S3 for SimpleStorage {
         &self,
         _req: S3Request<ListBucketsInput>,
     ) -> S3Result<S3Response<ListBucketsOutput>> {
+        let _timer = DurationRecorder::new("S3", "ListBuckets");
         let storage = Arc::clone(&self.inner);
         let names = blocking(move || storage.list_buckets())
             .await
@@ -187,6 +195,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<PutBucketVersioningInput>,
     ) -> S3Result<S3Response<PutBucketVersioningOutput>> {
+        let _timer = DurationRecorder::new("S3", "PutBucketVersioning");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
 
@@ -224,6 +233,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<GetBucketVersioningInput>,
     ) -> S3Result<S3Response<GetBucketVersioningOutput>> {
+        let _timer = DurationRecorder::new("S3", "GetBucketVersioning");
         let store = self.bucket(&req.input.bucket)?;
 
         let state = blocking(move || store.get_versioning_state())
@@ -252,6 +262,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<PutObjectInput>,
     ) -> S3Result<S3Response<PutObjectOutput>> {
+        let _timer = DurationRecorder::new("S3", "PutObject");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
 
@@ -297,6 +308,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<GetObjectInput>,
     ) -> S3Result<S3Response<GetObjectOutput>> {
+        let _timer = DurationRecorder::new("S3", "GetObject");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
 
@@ -344,6 +356,7 @@ impl S3 for SimpleStorage {
 
         #[allow(clippy::cast_possible_wrap)]
         let content_length = data.len() as i64;
+        metrics::counter!("simple3_bytes_sent_total").increment(data.len() as u64);
         let stream =
             futures::stream::once(async { Ok::<_, std::io::Error>(bytes::Bytes::from(data)) });
         let body = StreamingBlob::wrap(stream);
@@ -374,6 +387,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<HeadObjectInput>,
     ) -> S3Result<S3Response<HeadObjectOutput>> {
+        let _timer = DurationRecorder::new("S3", "HeadObject");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
 
@@ -417,6 +431,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<CopyObjectInput>,
     ) -> S3Result<S3Response<CopyObjectOutput>> {
+        let _timer = DurationRecorder::new("S3", "CopyObject");
         let input = req.input;
 
         let (src_bucket, src_key, src_version_id) = match input.copy_source {
@@ -506,6 +521,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<DeleteObjectInput>,
     ) -> S3Result<S3Response<DeleteObjectOutput>> {
+        let _timer = DurationRecorder::new("S3", "DeleteObject");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
 
@@ -544,6 +560,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<DeleteObjectsInput>,
     ) -> S3Result<S3Response<DeleteObjectsOutput>> {
+        let _timer = DurationRecorder::new("S3", "DeleteObjects");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
         let quiet = input.delete.quiet.unwrap_or(false);
@@ -650,6 +667,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<ListObjectsV2Input>,
     ) -> S3Result<S3Response<ListObjectsV2Output>> {
+        let _timer = DurationRecorder::new("S3", "ListObjectsV2");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
 
@@ -731,6 +749,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<ListObjectVersionsInput>,
     ) -> S3Result<S3Response<ListObjectVersionsOutput>> {
+        let _timer = DurationRecorder::new("S3", "ListObjectVersions");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
 
@@ -818,6 +837,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<CreateMultipartUploadInput>,
     ) -> S3Result<S3Response<CreateMultipartUploadOutput>> {
+        let _timer = DurationRecorder::new("S3", "CreateMultipartUpload");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
 
@@ -836,6 +856,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<UploadPartInput>,
     ) -> S3Result<S3Response<UploadPartOutput>> {
+        let _timer = DurationRecorder::new("S3", "UploadPart");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
 
@@ -846,6 +867,8 @@ impl S3 for SimpleStorage {
         while let Some(chunk) = stream.try_next().await.map_err(|e| { tracing::error!("upload_part: read body: {e}"); s3_error!(InternalError) })? {
             data.extend_from_slice(&chunk);
         }
+
+        metrics::counter!("simple3_bytes_received_total").increment(data.len() as u64);
 
         let upload_id = input.upload_id;
         let part_number = input.part_number;
@@ -864,6 +887,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<CompleteMultipartUploadInput>,
     ) -> S3Result<S3Response<CompleteMultipartUploadOutput>> {
+        let _timer = DurationRecorder::new("S3", "CompleteMultipartUpload");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
 
@@ -920,6 +944,7 @@ impl S3 for SimpleStorage {
         &self,
         req: S3Request<AbortMultipartUploadInput>,
     ) -> S3Result<S3Response<AbortMultipartUploadOutput>> {
+        let _timer = DurationRecorder::new("S3", "AbortMultipartUpload");
         let input = req.input;
         let store = self.bucket(&input.bucket)?;
 

--- a/src/storage/compaction.rs
+++ b/src/storage/compaction.rs
@@ -167,6 +167,14 @@ impl BucketStore {
 
     /// Compact a single segment. Only locks that segment during the swap phase.
     pub fn compact_segment(&self, segment_id: u32) -> io::Result<()> {
+        let start = std::time::Instant::now();
+        let bucket_name = self
+            .bucket_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_owned();
+
         // If compacting active segment, rotate first so it becomes non-active
         {
             let mut w = self
@@ -195,7 +203,24 @@ impl BucketStore {
         self.set_seg_compacting(segment_id, true)?;
 
         // Phase 2: Swap file + update redb under per-segment write lock
-        self.apply_compaction(&seg_arc, &tmp_path, &seg_path, &updated, segment_id)
+        let result =
+            self.apply_compaction(&seg_arc, &tmp_path, &seg_path, &updated, segment_id);
+
+        let status = if result.is_ok() { "ok" } else { "error" };
+        metrics::histogram!(
+            "simple3_compaction_duration_seconds",
+            "bucket" => bucket_name.clone(),
+            "status" => status,
+        )
+        .record(start.elapsed().as_secs_f64());
+        metrics::counter!(
+            "simple3_compaction_runs_total",
+            "bucket" => bucket_name,
+            "status" => status,
+        )
+        .increment(1);
+
+        result
     }
 
     /// Compact all segments that have dead bytes.

--- a/src/storage/compaction.rs
+++ b/src/storage/compaction.rs
@@ -175,6 +175,26 @@ impl BucketStore {
             .unwrap_or("unknown")
             .to_owned();
 
+        let result = self.compact_segment_inner(segment_id);
+
+        let status = if result.is_ok() { "ok" } else { "error" };
+        metrics::histogram!(
+            "simple3_compaction_duration_seconds",
+            "bucket" => bucket_name.clone(),
+            "status" => status,
+        )
+        .record(start.elapsed().as_secs_f64());
+        metrics::counter!(
+            "simple3_compaction_runs_total",
+            "bucket" => bucket_name,
+            "status" => status,
+        )
+        .increment(1);
+
+        result
+    }
+
+    fn compact_segment_inner(&self, segment_id: u32) -> io::Result<()> {
         // If compacting active segment, rotate first so it becomes non-active
         {
             let mut w = self
@@ -203,24 +223,7 @@ impl BucketStore {
         self.set_seg_compacting(segment_id, true)?;
 
         // Phase 2: Swap file + update redb under per-segment write lock
-        let result =
-            self.apply_compaction(&seg_arc, &tmp_path, &seg_path, &updated, segment_id);
-
-        let status = if result.is_ok() { "ok" } else { "error" };
-        metrics::histogram!(
-            "simple3_compaction_duration_seconds",
-            "bucket" => bucket_name.clone(),
-            "status" => status,
-        )
-        .record(start.elapsed().as_secs_f64());
-        metrics::counter!(
-            "simple3_compaction_runs_total",
-            "bucket" => bucket_name,
-            "status" => status,
-        )
-        .increment(1);
-
-        result
+        self.apply_compaction(&seg_arc, &tmp_path, &seg_path, &updated, segment_id)
     }
 
     /// Compact all segments that have dead bytes.


### PR DESCRIPTION
## Summary

- Add Prometheus metrics exposition at `GET /metrics` (no auth) using `metrics` + `metrics-exporter-prometheus` crates
- Instrument all S3 (18 methods) and gRPC (19 RPCs) operations with request duration histograms and byte counters
- Add per-bucket storage gauges (segments, dead bytes, dead space ratio) updated every 15s with stale bucket cleanup
- Add compaction duration/runs metrics with ok/error status labels and HTTP active connections gauge

## Metrics

| Metric | Type | Labels |
|--------|------|--------|
| `simple3_request_duration_seconds` | Histogram | `method`, `operation` |
| `simple3_bytes_received_total` | Counter | — |
| `simple3_bytes_sent_total` | Counter | — |
| `simple3_segments_total` | Gauge | `bucket` |
| `simple3_dead_bytes` | Gauge | `bucket` |
| `simple3_dead_space_ratio` | Gauge | `bucket` |
| `simple3_compaction_duration_seconds` | Histogram | `bucket`, `status` |
| `simple3_compaction_runs_total` | Counter | `bucket`, `status` |
| `simple3_connections_active` | Gauge | — |

## Files changed

- `Cargo.toml` — +2 deps (`metrics`, `metrics-exporter-prometheus`)
- `src/metrics_util.rs` — **new** `DurationRecorder` drop-guard + unit tests
- `src/cli/serve.rs` — Prometheus recorder init, `/metrics` route, `ConnectionGuard`, storage gauge updater + tests
- `src/s3impl.rs` — duration timers + byte counters on all S3 methods
- `src/grpc.rs` — duration timers on all gRPC RPCs
- `src/grpc_helpers.rs` — byte counters on streaming upload/download
- `src/storage/compaction.rs` — compaction metrics with status labels

## Test plan

- [x] `cargo build` passes
- [x] `cargo lint` passes (clippy pedantic + nursery)
- [x] `cargo test` passes (104 tests, +5 new metrics tests)
- [ ] Manual: `cargo run -- serve` then `curl localhost:8080/metrics` returns Prometheus text format
- [ ] Manual: upload/download objects, verify counters increment
- [ ] Manual: delete a bucket, verify stale gauges zeroed on next cycle

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics endpoint and monitoring.
  * Added request-duration and data-transfer metrics for RPC/gRPC and HTTP paths.
  * Added active connection tracking and a background updater to expose periodic storage metrics.
  * Added compaction metrics (duration, runs, status) for operational visibility.
* **Tests**
  * Added unit tests validating metrics, gauge updates, and metrics rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->