### PR TITLE
feat(ops): add structured JSON logging with per-request trace IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,8 +3586,10 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
+ "tower",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "walkdir",
 ]
 
@@ -4163,6 +4165,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4172,12 +4184,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4307,6 +4322,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ md-5 = "0.10"
 crc32c = "0.6"
 clap = { version = "4", features = ["derive", "env"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+uuid = { version = "1", features = ["v4"] }
+tower = { version = "0.5", default-features = false }
 futures = "0.3"
 bytes = "1"
 anyhow = "1"

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -20,6 +20,7 @@ pub struct ServerConfig {
     pub port: Option<u16>,
     pub grpc_port: Option<u16>,
     pub shutdown_timeout: Option<u64>,
+    pub log_format: Option<super::LogFormat>,
 }
 
 #[derive(Deserialize, Default)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,11 +1,12 @@
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 mod admin_auth;
 mod compact;
 mod health;
 mod metrics;
+mod request_id;
 pub mod client;
 pub mod config;
 pub mod keys;
@@ -24,8 +25,37 @@ pub struct Cli {
     #[arg(long, global = true)]
     config: Option<PathBuf>,
 
+    /// Log output format
+    #[arg(long, global = true, value_enum)]
+    log_format: Option<LogFormat>,
+
     #[command(subcommand)]
     command: Option<Command>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogFormat {
+    #[default]
+    Text,
+    Json,
+}
+
+fn init_logging(format: LogFormat) {
+    let filter = tracing_subscriber::EnvFilter::from_default_env();
+    match format {
+        LogFormat::Json => {
+            tracing_subscriber::fmt()
+                .json()
+                .with_env_filter(filter)
+                .init();
+        }
+        LogFormat::Text => {
+            tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .init();
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -188,6 +218,12 @@ enum Command {
 pub async fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    // For non-serve commands, init text logging immediately.
+    // Serve path defers init until after config load to support JSON format from TOML.
+    if !matches!(&cli.command, None | Some(Command::Serve { .. })) {
+        init_logging(cli.log_format.unwrap_or_default());
+    }
+
     match cli.command {
         Some(Command::Health) => health::run(&cli.data_dir, cli.config.as_deref()).await,
         Some(Command::Compact { bucket }) => compact::run(&cli.data_dir, bucket),
@@ -270,6 +306,11 @@ pub async fn run() -> anyhow::Result<()> {
         }
         cmd => {
             let cfg = config::load_config(cli.config.as_deref(), &cli.data_dir)?;
+            let log_format = cli
+                .log_format
+                .or(cfg.server.log_format)
+                .unwrap_or_default();
+            init_logging(log_format);
             let (
                 host,
                 port,

--- a/src/cli/request_id.rs
+++ b/src/cli/request_id.rs
@@ -1,0 +1,76 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tower::{Layer, Service};
+use tracing::Instrument;
+
+/// Generate a new request ID and insert it into the response headers.
+///
+/// Returns the UUID string for use in tracing spans.
+pub fn generate_request_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// Insert `x-request-id` into response headers.
+///
+/// UUID v4 strings are always valid ASCII header values, so `parse()` is infallible here.
+pub fn set_request_id_header<B>(resp: &mut hyper::Response<B>, request_id: &str) {
+    if let Ok(val) = request_id.parse() {
+        resp.headers_mut().insert("x-request-id", val);
+    }
+}
+
+// === Tower Layer for gRPC ===
+
+#[derive(Clone)]
+pub struct RequestIdLayer;
+
+impl<S> Layer<S> for RequestIdLayer {
+    type Service = RequestIdService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestIdService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct RequestIdService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> Service<hyper::Request<ReqBody>> for RequestIdService<S>
+where
+    S: Service<hyper::Request<ReqBody>, Response = hyper::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: hyper::Request<ReqBody>) -> Self::Future {
+        let request_id = generate_request_id();
+        let path = req.uri().path().to_owned();
+        let span = tracing::info_span!(
+            "grpc_request",
+            request_id = %request_id,
+            path = %path,
+        );
+        let mut inner = self.inner.clone();
+        Box::pin(
+            async move {
+                let mut resp = inner.call(req).await?;
+                set_request_id_header(&mut resp, &request_id);
+                Ok(resp)
+            }
+            .instrument(span),
+        )
+    }
+}

--- a/src/cli/request_id.rs
+++ b/src/cli/request_id.rs
@@ -57,11 +57,10 @@ where
 
     fn call(&mut self, req: hyper::Request<ReqBody>) -> Self::Future {
         let request_id = generate_request_id();
-        let path = req.uri().path().to_owned();
         let span = tracing::info_span!(
             "grpc_request",
             request_id = %request_id,
-            path = %path,
+            path = %req.uri().path(),
         );
         // Clone-and-swap: `self.inner` was marked ready by `poll_ready`, so we
         // move it into the future and replace it with a fresh clone. This follows

--- a/src/cli/request_id.rs
+++ b/src/cli/request_id.rs
@@ -63,7 +63,11 @@ where
             request_id = %request_id,
             path = %path,
         );
+        // Clone-and-swap: `self.inner` was marked ready by `poll_ready`, so we
+        // move it into the future and replace it with a fresh clone. This follows
+        // the tower `Service` contract — the ready instance is the one that gets called.
         let mut inner = self.inner.clone();
+        std::mem::swap(&mut self.inner, &mut inner);
         Box::pin(
             async move {
                 let mut resp = inner.call(req).await?;

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -13,6 +13,8 @@ use tokio::signal::unix::SignalKind;
 use tokio::sync::watch;
 use tokio::task::{JoinHandle, JoinSet};
 
+use tracing::Instrument;
+
 use simple3::auth::s3_auth::AuthProvider;
 use simple3::auth::types::BootstrapResult;
 use simple3::auth::AuthStore;
@@ -138,8 +140,36 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
     type Future = ServiceFuture;
 
     fn call(&self, req: hyper::Request<hyper::body::Incoming>) -> Self::Future {
+        let request_id = super::request_id::generate_request_id();
+        let method = req.method().clone();
         let path = req.uri().path().to_owned();
-        if *req.method() == hyper::Method::GET && path == "/metrics" {
+        let span = tracing::info_span!(
+            "http_request",
+            request_id = %request_id,
+            method = %method,
+            path = %path,
+        );
+
+        let fut = self.dispatch(req, &method, &path);
+        Box::pin(
+            async move {
+                let mut resp = fut.await?;
+                super::request_id::set_request_id_header(&mut resp, &request_id);
+                Ok(resp)
+            }
+            .instrument(span),
+        )
+    }
+}
+
+impl AdminService {
+    fn dispatch(
+        &self,
+        req: hyper::Request<hyper::body::Incoming>,
+        method: &hyper::Method,
+        path: &str,
+    ) -> ServiceFuture {
+        if *method == hyper::Method::GET && path == "/metrics" {
             let body = self.prometheus_handle.render();
             Box::pin(async move {
                 Ok(hyper::Response::builder()
@@ -150,11 +180,11 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
                         json_response(500, &serde_json::json!({"error": format!("metrics render: {e}")}))
                     }))
             })
-        } else if *req.method() == hyper::Method::GET && path == "/health" {
+        } else if *method == hyper::Method::GET && path == "/health" {
             Box::pin(async {
                 Ok(json_response(200, &serde_json::json!({"status": "ok"})))
             })
-        } else if *req.method() == hyper::Method::GET && path == "/ready" {
+        } else if *method == hyper::Method::GET && path == "/ready" {
             let storage = Arc::clone(&self.storage);
             let min_free = self.min_disk_free_mb;
             Box::pin(async move {
@@ -166,7 +196,8 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
             })
         } else if path.starts_with("/_/keys") || path.starts_with("/_/policies") {
             let auth_store = Arc::clone(&self.auth_store);
-            let method = req.method().clone();
+            let method = method.clone();
+            let path = path.to_owned();
             Box::pin(async move {
                 Ok(super::admin_auth::handle_admin_auth(req, &path, &method, auth_store).await)
             })
@@ -478,6 +509,7 @@ async fn spawn_grpc(
     let mut rx = shutdown_rx.clone();
     let handle = tokio::spawn(async move {
         if let Err(e) = tonic::transport::Server::builder()
+            .layer(super::request_id::RequestIdLayer)
             .add_service(
                 simple3::grpc::proto::simple3_server::Simple3Server::new(grpc_svc)
                     .max_decoding_message_size(64 * 1024 * 1024)
@@ -681,6 +713,99 @@ pub async fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn build_admin_service(dir: &std::path::Path) -> AdminService {
+        let storage = Arc::new(Storage::open(dir).unwrap());
+        let s3 = SimpleStorage::new(Arc::clone(&storage));
+        let (auth_store, _) = simple3::auth::AuthStore::open(dir).unwrap();
+        let auth_store = Arc::new(auth_store);
+        let auth_provider = AuthProvider::new(Arc::clone(&auth_store));
+        let mut builder = S3ServiceBuilder::new(s3);
+        builder.set_auth(auth_provider.clone());
+        builder.set_access(auth_provider);
+        let s3_service = builder.build();
+        let recorder =
+            metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let prometheus_handle = recorder.handle();
+
+        AdminService {
+            s3: s3_service,
+            storage,
+            auth_store,
+            min_disk_free_mb: 0,
+            prometheus_handle,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_request_id_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = build_admin_service(dir.path());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let _ = hyper::server::conn::http1::Builder::new()
+                .serve_connection(io, service)
+                .await;
+        });
+
+        let resp = reqwest::get(format!("http://127.0.0.1:{port}/health"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let header = resp
+            .headers()
+            .get("x-request-id")
+            .expect("response must include x-request-id header");
+        let id_str = header.to_str().unwrap();
+        uuid::Uuid::parse_str(id_str).expect("x-request-id must be a valid UUID");
+    }
+
+    #[tokio::test]
+    async fn test_request_id_unique_per_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = build_admin_service(dir.path());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(conn) => conn,
+                    Err(_) => break,
+                };
+                let svc = service.clone();
+                tokio::spawn(async move {
+                    let io = TokioIo::new(stream);
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(io, svc)
+                        .await;
+                });
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let r1 = client
+            .get(format!("http://127.0.0.1:{port}/health"))
+            .send()
+            .await
+            .unwrap();
+        let r2 = client
+            .get(format!("http://127.0.0.1:{port}/health"))
+            .send()
+            .await
+            .unwrap();
+
+        let id1 = r1.headers().get("x-request-id").unwrap().to_str().unwrap();
+        let id2 = r2.headers().get("x-request-id").unwrap().to_str().unwrap();
+        assert_ne!(id1, id2, "each request must get a unique request ID");
+    }
 
     #[test]
     fn test_ready_ok() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,5 @@ mod cli;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
-
     cli::run().await
 }


### PR DESCRIPTION
## Summary

Closes #13

- Add `--log-format` CLI flag (`text`|`json`) and `server.log_format` TOML config for structured JSON log output via `tracing-subscriber` JSON layer
- Generate UUID v4 `request_id` per HTTP and gRPC request, propagated through tracing spans to all log entries within request scope
- Return `x-request-id` in HTTP response headers for client-side correlation
- gRPC uses a tower middleware layer (`RequestIdLayer`) for automatic request ID instrumentation
- Default format remains human-readable text (backward compatible)

## Files changed

| File | Change |
|------|--------|
| `Cargo.toml` | Add `uuid`, `tower`; enable `json` feature on `tracing-subscriber` |
| `src/main.rs` | Defer tracing init to `cli::run()` |
| `src/cli/mod.rs` | `LogFormat` enum (`ValueEnum` + `Deserialize`), `--log-format` global arg, `init_logging()` |
| `src/cli/config.rs` | `log_format: Option<LogFormat>` in `ServerConfig` |
| `src/cli/serve.rs` | Wrap `AdminService::call()` with request ID span + header; wire layer into gRPC |
| `src/cli/request_id.rs` | **New** — shared helpers + tower `Layer`/`Service` for gRPC |

## Test plan

- [x] `cargo build` passes
- [x] `cargo lint` passes
- [x] `cargo test` — all 121 tests pass (2 new)
- [x] `test_request_id_header` — verifies `x-request-id` present and valid UUID
- [x] `test_request_id_unique_per_request` — verifies unique IDs across requests
- [ ] Manual: `cargo run -- serve --log-format json` → JSON log lines with `request_id`
- [ ] Manual: `curl -I http://localhost:8080/health` → `x-request-id` in headers
- [ ] Manual: default `cargo run -- serve` → text logs unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI option to choose logging format (Text or JSON).
  * Automatic per-request ID generation and propagation in responses for improved observability.

* **Tests**
  * Expanded test coverage to verify request-ID presence and uniqueness across requests.

* **Chores**
  * Updated dependencies to support logging and request-tracking features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->