### PR TITLE
feat(ops): add rate limiting and request size limits (#14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.8.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
 dependencies = [
  "cfg-if",
  "dashmap",
@@ -1636,7 +1636,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "getrandom 0.3.4",
- "no-std-compat",
+ "hashbrown 0.16.1",
  "nonzero_ext",
  "parking_lot",
  "portable-atomic",
@@ -2456,12 +2456,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
-
-[[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "nom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,6 +1238,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,9 +1603,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1600,6 +1622,28 @@ dependencies = [
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "governor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -1667,6 +1711,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2408,6 +2458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2471,12 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3561,6 +3623,7 @@ dependencies = [
  "crc32c",
  "criterion",
  "futures",
+ "governor",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
@@ -3636,6 +3699,15 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tempfile = "3"
 rand = "0.10"
 reqwest = { version = "0.12", default-features = false }
 toml = "1.0"
-governor = { version = "0.8", default-features = false, features = ["std", "dashmap", "jitter"] }
+governor = { version = "0.10", default-features = false, features = ["std", "dashmap", "jitter"] }
 nix = { version = "0.29", default-features = false, features = ["fs"] }
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tempfile = "3"
 rand = "0.10"
 reqwest = { version = "0.12", default-features = false }
 toml = "1.0"
+governor = { version = "0.8", default-features = false, features = ["std", "dashmap", "jitter"] }
 nix = { version = "0.29", default-features = false, features = ["fs"] }
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -21,6 +21,8 @@ pub struct ServerConfig {
     pub grpc_port: Option<u16>,
     pub shutdown_timeout: Option<u64>,
     pub log_format: Option<super::LogFormat>,
+    /// Per-IP rate limit in requests/second (0 = disabled)
+    pub rate_limit_rps: Option<u32>,
 }
 
 #[derive(Deserialize, Default)]
@@ -30,6 +32,10 @@ pub struct StorageConfig {
     pub autovacuum_threshold: Option<f64>,
     pub scrub_interval: Option<u64>,
     pub min_disk_free_mb: Option<u64>,
+    /// Maximum object size in megabytes (0 = unlimited)
+    pub max_object_size_mb: Option<u64>,
+    /// Maximum keys per `ListObjects` page
+    pub max_list_keys: Option<u32>,
 }
 
 // Parsed from TOML but not yet wired into server startup

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -232,7 +232,7 @@ fn resolve_limits(
     cfg: &config::StorageConfig,
 ) -> simple3::limits::Limits {
     let mb = max_obj_mb.or(cfg.max_object_size_mb).unwrap_or(5120);
-    // checked_mul guards against overflow on very large MB values
+    // saturating_mul guards against overflow on very large MB values
     let max_object_size = mb.saturating_mul(1024 * 1024);
     #[allow(clippy::cast_possible_truncation)] // u32 -> usize: max_list_keys fits in usize on all platforms
     let max_list_keys = max_list.or(cfg.max_list_keys).unwrap_or(1000) as usize;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -225,6 +225,23 @@ enum Command {
     },
 }
 
+/// Resolve `Limits` from CLI args (if provided) falling back to TOML config, then defaults.
+fn resolve_limits(
+    max_obj_mb: Option<u64>,
+    max_list: Option<u32>,
+    cfg: &config::StorageConfig,
+) -> simple3::limits::Limits {
+    let mb = max_obj_mb.or(cfg.max_object_size_mb).unwrap_or(5120);
+    // checked_mul guards against overflow on very large MB values
+    let max_object_size = mb.saturating_mul(1024 * 1024);
+    #[allow(clippy::cast_possible_truncation)] // u32 -> usize: max_list_keys fits in usize on all platforms
+    let max_list_keys = max_list.or(cfg.max_list_keys).unwrap_or(1000) as usize;
+    simple3::limits::Limits {
+        max_object_size,
+        max_list_keys,
+    }
+}
+
 #[allow(clippy::too_many_lines)] // single dispatch for all subcommands, splitting would hurt readability
 pub async fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
@@ -353,18 +370,7 @@ pub async fn run() -> anyhow::Result<()> {
                     rate_limit_rps: rate_limit_rps
                         .or(cfg.server.rate_limit_rps)
                         .unwrap_or(0),
-                    limits: simple3::limits::Limits {
-                        max_object_size: max_object_size_mb
-                            .or(cfg.storage.max_object_size_mb)
-                            .unwrap_or(5120)
-                            * 1024
-                            * 1024,
-                        #[allow(clippy::cast_possible_truncation)]
-                        max_list_keys: max_list_keys
-                            .or(cfg.storage.max_list_keys)
-                            .unwrap_or(1000)
-                            as usize,
-                    },
+                    limits: resolve_limits(max_object_size_mb, max_list_keys, &cfg.storage),
                 },
                 _ => serve_config::ServeConfig {
                     host: cfg.server.host.unwrap_or_else(|| "0.0.0.0".into()),
@@ -377,20 +383,7 @@ pub async fn run() -> anyhow::Result<()> {
                     shutdown_timeout: cfg.server.shutdown_timeout.unwrap_or(30),
                     min_disk_free_mb: cfg.storage.min_disk_free_mb.unwrap_or(0),
                     rate_limit_rps: cfg.server.rate_limit_rps.unwrap_or(0),
-                    limits: simple3::limits::Limits {
-                        max_object_size: cfg
-                            .storage
-                            .max_object_size_mb
-                            .unwrap_or(5120)
-                            * 1024
-                            * 1024,
-                        #[allow(clippy::cast_possible_truncation)]
-                        max_list_keys: cfg
-                            .storage
-                            .max_list_keys
-                            .unwrap_or(1000)
-                            as usize,
-                    },
+                    limits: resolve_limits(None, None, &cfg.storage),
                 },
             };
             serve::run(&cli.data_dir, serve_cfg).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,12 +6,14 @@ mod admin_auth;
 mod compact;
 mod health;
 mod metrics;
+pub mod rate_limit;
 mod request_id;
 pub mod client;
 pub mod config;
 pub mod keys;
 pub mod policy_cmd;
 pub mod serve;
+pub mod serve_config;
 pub mod util;
 mod verify;
 
@@ -87,6 +89,15 @@ enum Command {
         /// Minimum free disk space in MB; /ready returns 503 below this (0 = disabled)
         #[arg(long)]
         min_disk_free_mb: Option<u64>,
+        /// Maximum object size in megabytes (0 = unlimited, default 5120 = 5 GB)
+        #[arg(long)]
+        max_object_size_mb: Option<u64>,
+        /// Maximum keys per `ListObjects` page (default 1000)
+        #[arg(long)]
+        max_list_keys: Option<u32>,
+        /// Per-IP rate limit in requests/second (0 = disabled)
+        #[arg(long)]
+        rate_limit_rps: Option<u32>,
     },
     /// Check if the running server is healthy
     Health,
@@ -311,17 +322,7 @@ pub async fn run() -> anyhow::Result<()> {
                 .or(cfg.server.log_format)
                 .unwrap_or_default();
             init_logging(log_format);
-            let (
-                host,
-                port,
-                av_interval,
-                av_threshold,
-                max_seg_mb,
-                grpc_port,
-                scrub_interval,
-                shutdown_timeout,
-                min_disk_free_mb,
-            ) = match cmd {
+            let serve_cfg = match cmd {
                 Some(Command::Serve {
                     host,
                     port,
@@ -332,46 +333,67 @@ pub async fn run() -> anyhow::Result<()> {
                     scrub_interval,
                     shutdown_timeout,
                     min_disk_free_mb,
-                }) => (
+                    max_object_size_mb,
+                    max_list_keys,
+                    rate_limit_rps,
+                }) => serve_config::ServeConfig {
                     host,
                     port,
+                    grpc_port,
                     autovacuum_interval,
                     autovacuum_threshold,
                     max_segment_size_mb,
-                    grpc_port,
                     scrub_interval,
-                    shutdown_timeout
+                    shutdown_timeout: shutdown_timeout
                         .or(cfg.server.shutdown_timeout)
                         .unwrap_or(30),
-                    min_disk_free_mb
+                    min_disk_free_mb: min_disk_free_mb
                         .or(cfg.storage.min_disk_free_mb)
                         .unwrap_or(0),
-                ),
-                _ => (
-                    cfg.server.host.unwrap_or_else(|| "0.0.0.0".into()),
-                    cfg.server.port.unwrap_or(8080),
-                    cfg.storage.autovacuum_interval.unwrap_or(300),
-                    cfg.storage.autovacuum_threshold.unwrap_or(0.5),
-                    cfg.storage.max_segment_size_mb.unwrap_or(4096),
-                    cfg.server.grpc_port.unwrap_or(50051),
-                    cfg.storage.scrub_interval.unwrap_or(3600),
-                    cfg.server.shutdown_timeout.unwrap_or(30),
-                    cfg.storage.min_disk_free_mb.unwrap_or(0),
-                ),
+                    rate_limit_rps: rate_limit_rps
+                        .or(cfg.server.rate_limit_rps)
+                        .unwrap_or(0),
+                    limits: simple3::limits::Limits {
+                        max_object_size: max_object_size_mb
+                            .or(cfg.storage.max_object_size_mb)
+                            .unwrap_or(5120)
+                            * 1024
+                            * 1024,
+                        #[allow(clippy::cast_possible_truncation)]
+                        max_list_keys: max_list_keys
+                            .or(cfg.storage.max_list_keys)
+                            .unwrap_or(1000)
+                            as usize,
+                    },
+                },
+                _ => serve_config::ServeConfig {
+                    host: cfg.server.host.unwrap_or_else(|| "0.0.0.0".into()),
+                    port: cfg.server.port.unwrap_or(8080),
+                    grpc_port: cfg.server.grpc_port.unwrap_or(50051),
+                    autovacuum_interval: cfg.storage.autovacuum_interval.unwrap_or(300),
+                    autovacuum_threshold: cfg.storage.autovacuum_threshold.unwrap_or(0.5),
+                    max_segment_size_mb: cfg.storage.max_segment_size_mb.unwrap_or(4096),
+                    scrub_interval: cfg.storage.scrub_interval.unwrap_or(3600),
+                    shutdown_timeout: cfg.server.shutdown_timeout.unwrap_or(30),
+                    min_disk_free_mb: cfg.storage.min_disk_free_mb.unwrap_or(0),
+                    rate_limit_rps: cfg.server.rate_limit_rps.unwrap_or(0),
+                    limits: simple3::limits::Limits {
+                        max_object_size: cfg
+                            .storage
+                            .max_object_size_mb
+                            .unwrap_or(5120)
+                            * 1024
+                            * 1024,
+                        #[allow(clippy::cast_possible_truncation)]
+                        max_list_keys: cfg
+                            .storage
+                            .max_list_keys
+                            .unwrap_or(1000)
+                            as usize,
+                    },
+                },
             };
-            serve::run(
-                &cli.data_dir,
-                &host,
-                port,
-                grpc_port,
-                av_interval,
-                av_threshold,
-                max_seg_mb,
-                scrub_interval,
-                shutdown_timeout,
-                min_disk_free_mb,
-            )
-            .await
+            serve::run(&cli.data_dir, serve_cfg).await
         }
     }
 }

--- a/src/cli/rate_limit.rs
+++ b/src/cli/rate_limit.rs
@@ -10,13 +10,34 @@ use governor::{Quota, RateLimiter};
 pub type IpRateLimiter = RateLimiter<IpAddr, DashMapStateStore<IpAddr>, DefaultClock>;
 
 /// Build a per-IP token-bucket rate limiter. Returns `None` when `rps == 0` (disabled).
+///
+/// Uses `DashMapStateStore` which grows one entry per unique IP and never evicts.
+/// TODO: add periodic cleanup or bounded LRU store for long-running servers
+/// exposed to many unique IPs.
 pub fn build_rate_limiter(rps: u32) -> Option<Arc<IpRateLimiter>> {
     let rps = NonZeroU32::new(rps)?;
     let quota = Quota::per_second(rps);
     Some(Arc::new(RateLimiter::dashmap(quota)))
 }
 
-// --- Tower layer for gRPC rate limiting ---
+/// Extract peer IP from request extensions.
+/// Checks for direct `IpAddr` (set by HTTP `PeerIpService`) first,
+/// then falls back to tonic's `TcpConnectInfo` (set automatically for gRPC).
+fn extract_peer_ip<B>(req: &hyper::Request<B>) -> IpAddr {
+    if let Some(ip) = req.extensions().get::<IpAddr>().copied() {
+        return ip;
+    }
+    if let Some(info) = req
+        .extensions()
+        .get::<tonic::transport::server::TcpConnectInfo>()
+        && let Some(addr) = info.remote_addr()
+    {
+        return addr.ip();
+    }
+    IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED)
+}
+
+// --- Tower layer: per-IP rate limiting ---
 
 /// Tower layer that applies per-IP rate limiting.
 #[derive(Clone)]
@@ -71,11 +92,7 @@ where
     }
 
     fn call(&mut self, req: hyper::Request<ReqBody>) -> Self::Future {
-        let peer_ip = req
-            .extensions()
-            .get::<IpAddr>()
-            .copied()
-            .unwrap_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+        let peer_ip = extract_peer_ip(&req);
 
         if self.limiter.check_key(&peer_ip).is_err() {
             metrics::counter!("simple3_rate_limited_total", "protocol" => "grpc").increment(1);
@@ -85,7 +102,7 @@ where
                 .header("grpc-status", "8") // RESOURCE_EXHAUSTED
                 .header("grpc-message", "rate%20limit%20exceeded")
                 .body(ResBody::default())
-                .expect("static response");
+                .expect("static response"); // safe: all headers are static literals
             return futures::future::Either::Right(std::future::ready(Ok(resp)));
         }
 

--- a/src/cli/rate_limit.rs
+++ b/src/cli/rate_limit.rs
@@ -20,6 +20,26 @@ pub fn build_rate_limiter(rps: u32) -> Option<Arc<IpRateLimiter>> {
     Some(Arc::new(RateLimiter::dashmap(quota)))
 }
 
+/// Periodically prune stale entries from the per-IP rate limiter.
+/// Runs every 5 minutes until a shutdown signal is received.
+pub fn spawn_cleanup(
+    limiter: Arc<IpRateLimiter>,
+    shutdown_rx: &tokio::sync::watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    let mut rx = shutdown_rx.clone();
+    tokio::spawn(async move {
+        let interval = std::time::Duration::from_secs(300);
+        loop {
+            tokio::select! {
+                () = tokio::time::sleep(interval) => {}
+                _ = rx.changed() => break,
+            }
+            limiter.retain_recent();
+            limiter.shrink_to_fit();
+        }
+    })
+}
+
 /// Extract peer IP from request extensions.
 /// Checks for direct `IpAddr` (set by HTTP `PeerIpService`) first,
 /// then falls back to tonic's `TcpConnectInfo` (set automatically for gRPC).

--- a/src/cli/rate_limit.rs
+++ b/src/cli/rate_limit.rs
@@ -1,0 +1,94 @@
+use std::net::IpAddr;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use governor::clock::DefaultClock;
+use governor::state::keyed::DashMapStateStore;
+use governor::{Quota, RateLimiter};
+
+pub type IpRateLimiter = RateLimiter<IpAddr, DashMapStateStore<IpAddr>, DefaultClock>;
+
+/// Build a per-IP token-bucket rate limiter. Returns `None` when `rps == 0` (disabled).
+pub fn build_rate_limiter(rps: u32) -> Option<Arc<IpRateLimiter>> {
+    let rps = NonZeroU32::new(rps)?;
+    let quota = Quota::per_second(rps);
+    Some(Arc::new(RateLimiter::dashmap(quota)))
+}
+
+// --- Tower layer for gRPC rate limiting ---
+
+/// Tower layer that applies per-IP rate limiting.
+#[derive(Clone)]
+pub struct RateLimitLayer {
+    limiter: Arc<IpRateLimiter>,
+}
+
+impl RateLimitLayer {
+    pub const fn new(limiter: Arc<IpRateLimiter>) -> Self {
+        Self { limiter }
+    }
+}
+
+impl<S> tower::Layer<S> for RateLimitLayer {
+    type Service = RateLimitService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RateLimitService {
+            inner,
+            limiter: Arc::clone(&self.limiter),
+        }
+    }
+}
+
+/// Tower service that checks rate limits before forwarding requests.
+#[derive(Clone)]
+pub struct RateLimitService<S> {
+    inner: S,
+    limiter: Arc<IpRateLimiter>,
+}
+
+impl<S, ReqBody, ResBody> tower::Service<hyper::Request<ReqBody>> for RateLimitService<S>
+where
+    S: tower::Service<hyper::Request<ReqBody>, Response = hyper::Response<ResBody>>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Default + Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = futures::future::Either<
+        S::Future,
+        std::future::Ready<Result<Self::Response, Self::Error>>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: hyper::Request<ReqBody>) -> Self::Future {
+        let peer_ip = req
+            .extensions()
+            .get::<IpAddr>()
+            .copied()
+            .unwrap_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+
+        if self.limiter.check_key(&peer_ip).is_err() {
+            metrics::counter!("simple3_rate_limited_total", "protocol" => "grpc").increment(1);
+            let resp = hyper::Response::builder()
+                .status(hyper::StatusCode::OK)
+                .header("content-type", "application/grpc")
+                .header("grpc-status", "8") // RESOURCE_EXHAUSTED
+                .header("grpc-message", "rate%20limit%20exceeded")
+                .body(ResBody::default())
+                .expect("static response");
+            return futures::future::Either::Right(std::future::ready(Ok(resp)));
+        }
+
+        futures::future::Either::Left(self.inner.call(req))
+    }
+}

--- a/src/cli/rate_limit.rs
+++ b/src/cli/rate_limit.rs
@@ -11,9 +11,8 @@ pub type IpRateLimiter = RateLimiter<IpAddr, DashMapStateStore<IpAddr>, DefaultC
 
 /// Build a per-IP token-bucket rate limiter. Returns `None` when `rps == 0` (disabled).
 ///
-/// Uses `DashMapStateStore` which grows one entry per unique IP and never evicts.
-/// TODO: add periodic cleanup or bounded LRU store for long-running servers
-/// exposed to many unique IPs.
+/// Uses `DashMapStateStore` with periodic `retain_recent()` cleanup (see `spawn_cleanup`).
+/// TODO: consider a bounded LRU store for servers exposed to very many unique IPs.
 pub fn build_rate_limiter(rps: u32) -> Option<Arc<IpRateLimiter>> {
     let rps = NonZeroU32::new(rps)?;
     let quota = Quota::per_second(rps);

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -164,11 +164,17 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
             if limiter.check_key(&peer_ip).is_err() {
                 metrics::counter!("simple3_rate_limited_total", "protocol" => "http")
                     .increment(1);
+                let body = r#"{"error":"SlowDown","message":"Rate limit exceeded"}"#.to_owned();
                 return Box::pin(async {
-                    Ok(json_response(
-                        429,
-                        &serde_json::json!({"error": "SlowDown", "message": "Rate limit exceeded"}),
-                    ))
+                    Ok(hyper::Response::builder()
+                        .status(429)
+                        .header("content-type", "application/json")
+                        .header("retry-after", "1")
+                        .body(s3s::Body::from(body))
+                        .unwrap_or_else(|e| json_response(
+                            500,
+                            &serde_json::json!({"error": format!("rate limit response: {e}")}),
+                        )))
                 });
             }
         }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -129,6 +129,7 @@ struct AdminService {
     auth_store: Arc<AuthStore>,
     min_disk_free_mb: u64,
     prometheus_handle: metrics_exporter_prometheus::PrometheusHandle,
+    rate_limiter: Option<Arc<super::rate_limit::IpRateLimiter>>,
 }
 
 type ServiceFuture =
@@ -149,6 +150,28 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
             method = %method,
             path = %path,
         );
+
+        // Rate limit check (exempt health/ready endpoints)
+        if path != "/health"
+            && path != "/ready"
+            && let Some(ref limiter) = self.rate_limiter
+        {
+            let peer_ip = req
+                .extensions()
+                .get::<std::net::IpAddr>()
+                .copied()
+                .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+            if limiter.check_key(&peer_ip).is_err() {
+                metrics::counter!("simple3_rate_limited_total", "protocol" => "http")
+                    .increment(1);
+                return Box::pin(async {
+                    Ok(json_response(
+                        429,
+                        &serde_json::json!({"error": "SlowDown", "message": "Rate limit exceeded"}),
+                    ))
+                });
+            }
+        }
 
         let fut = self.dispatch(req, &method, &path);
         Box::pin(
@@ -500,26 +523,42 @@ async fn spawn_grpc(
     host: &str,
     port: u16,
     shutdown_rx: &watch::Receiver<bool>,
+    limits: simple3::limits::Limits,
+    rate_limiter: Option<Arc<super::rate_limit::IpRateLimiter>>,
 ) -> anyhow::Result<JoinHandle<()>> {
-    let grpc_svc =
-        simple3::grpc::GrpcService::new(Arc::clone(storage), Some(Arc::clone(auth_store)));
+    let grpc_svc = simple3::grpc::GrpcService::new(
+        Arc::clone(storage),
+        Some(Arc::clone(auth_store)),
+        limits,
+    );
     let listener = TcpListener::bind(format!("{host}:{port}")).await?;
     tracing::info!("gRPC listening on {}:{}", host, port);
     let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
     let mut rx = shutdown_rx.clone();
+    let grpc_service =
+        simple3::grpc::proto::simple3_server::Simple3Server::new(grpc_svc)
+            .max_decoding_message_size(64 * 1024 * 1024)
+            .max_encoding_message_size(64 * 1024 * 1024);
     let handle = tokio::spawn(async move {
-        if let Err(e) = tonic::transport::Server::builder()
-            .layer(super::request_id::RequestIdLayer)
-            .add_service(
-                simple3::grpc::proto::simple3_server::Simple3Server::new(grpc_svc)
-                    .max_decoding_message_size(64 * 1024 * 1024)
-                    .max_encoding_message_size(64 * 1024 * 1024),
-            )
-            .serve_with_incoming_shutdown(incoming, async move {
-                let _ = rx.changed().await;
-            })
-            .await
-        {
+        let result = if let Some(limiter) = rate_limiter {
+            tonic::transport::Server::builder()
+                .layer(super::request_id::RequestIdLayer)
+                .layer(super::rate_limit::RateLimitLayer::new(limiter))
+                .add_service(grpc_service)
+                .serve_with_incoming_shutdown(incoming, async move {
+                    let _ = rx.changed().await;
+                })
+                .await
+        } else {
+            tonic::transport::Server::builder()
+                .layer(super::request_id::RequestIdLayer)
+                .add_service(grpc_service)
+                .serve_with_incoming_shutdown(incoming, async move {
+                    let _ = rx.changed().await;
+                })
+                .await
+        };
+        if let Err(e) = result {
             tracing::error!("gRPC server error: {e}");
         }
     });
@@ -564,6 +603,24 @@ async fn drain_connections(connections: &mut JoinSet<()>, timeout_secs: u64) {
     }
 }
 
+/// Wrapper that injects peer IP into request extensions before forwarding.
+#[derive(Clone)]
+struct PeerIpService {
+    inner: AdminService,
+    peer_ip: std::net::IpAddr,
+}
+
+impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for PeerIpService {
+    type Response = s3s::HttpResponse;
+    type Error = s3s::HttpError;
+    type Future = ServiceFuture;
+
+    fn call(&self, mut req: hyper::Request<hyper::body::Incoming>) -> Self::Future {
+        req.extensions_mut().insert(self.peer_ip);
+        self.inner.call(req)
+    }
+}
+
 /// Accept HTTP connections until a shutdown signal is received.
 /// Returns the in-flight connection set for draining by the caller.
 async fn accept_loop(
@@ -577,9 +634,9 @@ async fn accept_loop(
     loop {
         tokio::select! {
             result = listener.accept() => {
-                let (stream, _addr) = result?;
+                let (stream, addr) = result?;
                 let conn_guard = ConnectionGuard::new();
-                let svc = service.clone();
+                let svc = PeerIpService { inner: service.clone(), peer_ip: addr.ip() };
                 let mut rx = shutdown_rx.clone();
                 connections.spawn(async move {
                     let _conn_guard = conn_guard;
@@ -610,22 +667,13 @@ async fn accept_loop(
     Ok(connections)
 }
 
-#[allow(clippy::too_many_arguments)] // server config values passed through
 pub async fn run(
     data_dir: &Path,
-    host: &str,
-    port: u16,
-    grpc_port: u16,
-    autovacuum_interval: u64,
-    autovacuum_threshold: f64,
-    max_segment_size_mb: u64,
-    scrub_interval: u64,
-    shutdown_timeout: u64,
-    min_disk_free_mb: u64,
+    cfg: super::serve_config::ServeConfig,
 ) -> anyhow::Result<()> {
-    let max_seg_bytes = max_segment_size_mb * 1024 * 1024;
+    let max_seg_bytes = cfg.max_segment_size_mb * 1024 * 1024;
     let storage = Arc::new(Storage::open_with_segment_size(data_dir, max_seg_bytes)?);
-    let s3 = SimpleStorage::new(Arc::clone(&storage));
+    let s3 = SimpleStorage::new(Arc::clone(&storage), cfg.limits.clone());
 
     // Open auth database and bootstrap root key if needed
     let (auth_store, bootstrap) = AuthStore::open(data_dir)?;
@@ -643,6 +691,8 @@ pub async fn run(
         eprintln!("================================================================");
     }
 
+    let rate_limiter = super::rate_limit::build_rate_limiter(cfg.rate_limit_rps);
+
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let sigterm = tokio::signal::unix::signal(SignalKind::terminate())?;
     let sigint = tokio::signal::unix::signal(SignalKind::interrupt())?;
@@ -650,14 +700,14 @@ pub async fn run(
 
     let mut bg_tasks: Vec<JoinHandle<()>> = Vec::new();
 
-    if autovacuum_interval > 0 {
+    if cfg.autovacuum_interval > 0 {
         bg_tasks.push(spawn_autovacuum(
-            &storage, autovacuum_interval, autovacuum_threshold, &shutdown_rx,
+            &storage, cfg.autovacuum_interval, cfg.autovacuum_threshold, &shutdown_rx,
         ));
     }
 
-    if scrub_interval > 0 {
-        bg_tasks.push(spawn_scrub(&storage, scrub_interval, &shutdown_rx));
+    if cfg.scrub_interval > 0 {
+        bg_tasks.push(spawn_scrub(&storage, cfg.scrub_interval, &shutdown_rx));
     }
 
     let prometheus_handle = metrics_exporter_prometheus::PrometheusBuilder::new()
@@ -676,22 +726,34 @@ pub async fn run(
         s3: s3_service,
         storage: Arc::clone(&storage),
         auth_store: Arc::clone(&auth_store),
-        min_disk_free_mb,
+        min_disk_free_mb: cfg.min_disk_free_mb,
         prometheus_handle,
+        rate_limiter: rate_limiter.clone(),
     };
 
-    if grpc_port > 0 {
-        bg_tasks.push(spawn_grpc(&storage, &auth_store, host, grpc_port, &shutdown_rx).await?);
+    if cfg.grpc_port > 0 {
+        bg_tasks.push(
+            spawn_grpc(
+                &storage,
+                &auth_store,
+                &cfg.host,
+                cfg.grpc_port,
+                &shutdown_rx,
+                cfg.limits.clone(),
+                rate_limiter,
+            )
+            .await?,
+        );
     }
 
-    let listener = TcpListener::bind((host, port)).await?;
-    tracing::info!("S3 HTTP listening on {}:{}", host, port);
+    let listener = TcpListener::bind((&*cfg.host, cfg.port)).await?;
+    tracing::info!("S3 HTTP listening on {}:{}", cfg.host, cfg.port);
 
     let mut connections = accept_loop(listener, service, &shutdown_rx).await?;
 
     tokio::join!(
-        drain_connections(&mut connections, shutdown_timeout),
-        await_bg_tasks(&mut bg_tasks, shutdown_timeout),
+        drain_connections(&mut connections, cfg.shutdown_timeout),
+        await_bg_tasks(&mut bg_tasks, cfg.shutdown_timeout),
     );
 
     match tokio::task::spawn_blocking(move || storage.sync_all()).await {
@@ -716,7 +778,7 @@ mod tests {
 
     fn build_admin_service(dir: &std::path::Path) -> AdminService {
         let storage = Arc::new(Storage::open(dir).unwrap());
-        let s3 = SimpleStorage::new(Arc::clone(&storage));
+        let s3 = SimpleStorage::new(Arc::clone(&storage), simple3::limits::Limits::default());
         let (auth_store, _) = simple3::auth::AuthStore::open(dir).unwrap();
         let auth_store = Arc::new(auth_store);
         let auth_provider = AuthProvider::new(Arc::clone(&auth_store));
@@ -734,6 +796,7 @@ mod tests {
             auth_store,
             min_disk_free_mb: 0,
             prometheus_handle,
+            rate_limiter: None,
         }
     }
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -151,9 +151,10 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
             path = %path,
         );
 
-        // Rate limit check (exempt health/ready endpoints)
+        // Rate limit check (exempt health/ready/metrics endpoints)
         if path != "/health"
             && path != "/ready"
+            && path != "/metrics"
             && let Some(ref limiter) = self.rate_limiter
         {
             let peer_ip = req
@@ -164,11 +165,14 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
             if limiter.check_key(&peer_ip).is_err() {
                 metrics::counter!("simple3_rate_limited_total", "protocol" => "http")
                     .increment(1);
-                let body = r#"{"error":"SlowDown","message":"Rate limit exceeded"}"#.to_owned();
+                let body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+                    <Error><Code>SlowDown</Code>\
+                    <Message>Rate limit exceeded</Message></Error>"
+                    .to_owned();
                 return Box::pin(async {
                     Ok(hyper::Response::builder()
-                        .status(429)
-                        .header("content-type", "application/json")
+                        .status(503)
+                        .header("content-type", "application/xml")
                         .header("retry-after", "1")
                         .body(s3s::Body::from(body))
                         .unwrap_or_else(|e| json_response(

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -166,21 +166,35 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
 
         let fut: ServiceFuture = if rate_limited {
             metrics::counter!("simple3_rate_limited_total", "protocol" => "http").increment(1);
-            let body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-                <Error><Code>SlowDown</Code>\
-                <Message>Rate limit exceeded</Message></Error>"
-                .to_owned();
-            Box::pin(async {
-                Ok(hyper::Response::builder()
-                    .status(503)
-                    .header("content-type", "application/xml")
-                    .header("retry-after", "1")
-                    .body(s3s::Body::from(body))
-                    .unwrap_or_else(|e| json_response(
-                        500,
-                        &serde_json::json!({"error": format!("rate limit response: {e}")}),
-                    )))
-            })
+            if path.starts_with("/_/") {
+                // Admin endpoints use JSON
+                Box::pin(async {
+                    let mut resp = json_response(
+                        503,
+                        &serde_json::json!({"error": "SlowDown", "message": "Rate limit exceeded"}),
+                    );
+                    resp.headers_mut()
+                        .insert("retry-after", hyper::header::HeaderValue::from_static("1"));
+                    Ok(resp)
+                })
+            } else {
+                // S3 endpoints use XML
+                let body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+                    <Error><Code>SlowDown</Code>\
+                    <Message>Rate limit exceeded</Message></Error>"
+                    .to_owned();
+                Box::pin(async {
+                    Ok(hyper::Response::builder()
+                        .status(503)
+                        .header("content-type", "application/xml")
+                        .header("retry-after", "1")
+                        .body(s3s::Body::from(body))
+                        .unwrap_or_else(|e| json_response(
+                            500,
+                            &serde_json::json!({"error": format!("rate limit response: {e}")}),
+                        )))
+                })
+            }
         } else {
             self.dispatch(req, &method, &path)
         };
@@ -682,7 +696,7 @@ pub async fn run(
     data_dir: &Path,
     cfg: super::serve_config::ServeConfig,
 ) -> anyhow::Result<()> {
-    let max_seg_bytes = cfg.max_segment_size_mb * 1024 * 1024;
+    let max_seg_bytes = cfg.max_segment_size_mb.saturating_mul(1024 * 1024);
     let storage = Arc::new(Storage::open_with_segment_size(data_dir, max_seg_bytes)?);
     let s3 = SimpleStorage::new(Arc::clone(&storage), cfg.limits.clone());
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -152,38 +152,39 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
         );
 
         // Rate limit check (exempt health/ready/metrics endpoints)
-        if path != "/health"
+        let rate_limited = path != "/health"
             && path != "/ready"
             && path != "/metrics"
-            && let Some(ref limiter) = self.rate_limiter
-        {
-            let peer_ip = req
-                .extensions()
-                .get::<std::net::IpAddr>()
-                .copied()
-                .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
-            if limiter.check_key(&peer_ip).is_err() {
-                metrics::counter!("simple3_rate_limited_total", "protocol" => "http")
-                    .increment(1);
-                let body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-                    <Error><Code>SlowDown</Code>\
-                    <Message>Rate limit exceeded</Message></Error>"
-                    .to_owned();
-                return Box::pin(async {
-                    Ok(hyper::Response::builder()
-                        .status(503)
-                        .header("content-type", "application/xml")
-                        .header("retry-after", "1")
-                        .body(s3s::Body::from(body))
-                        .unwrap_or_else(|e| json_response(
-                            500,
-                            &serde_json::json!({"error": format!("rate limit response: {e}")}),
-                        )))
-                });
-            }
-        }
+            && self.rate_limiter.as_ref().is_some_and(|limiter| {
+                let peer_ip = req
+                    .extensions()
+                    .get::<std::net::IpAddr>()
+                    .copied()
+                    .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+                limiter.check_key(&peer_ip).is_err()
+            });
 
-        let fut = self.dispatch(req, &method, &path);
+        let fut: ServiceFuture = if rate_limited {
+            metrics::counter!("simple3_rate_limited_total", "protocol" => "http").increment(1);
+            let body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+                <Error><Code>SlowDown</Code>\
+                <Message>Rate limit exceeded</Message></Error>"
+                .to_owned();
+            Box::pin(async {
+                Ok(hyper::Response::builder()
+                    .status(503)
+                    .header("content-type", "application/xml")
+                    .header("retry-after", "1")
+                    .body(s3s::Body::from(body))
+                    .unwrap_or_else(|e| json_response(
+                        500,
+                        &serde_json::json!({"error": format!("rate limit response: {e}")}),
+                    )))
+            })
+        } else {
+            self.dispatch(req, &method, &path)
+        };
+
         Box::pin(
             async move {
                 let mut resp = fut.await?;
@@ -709,6 +710,13 @@ pub async fn run(
     spawn_signal_handler(sigterm, sigint, shutdown_tx);
 
     let mut bg_tasks: Vec<JoinHandle<()>> = Vec::new();
+
+    if let Some(ref limiter) = rate_limiter {
+        bg_tasks.push(super::rate_limit::spawn_cleanup(
+            Arc::clone(limiter),
+            &shutdown_rx,
+        ));
+    }
 
     if cfg.autovacuum_interval > 0 {
         bg_tasks.push(spawn_autovacuum(

--- a/src/cli/serve_config.rs
+++ b/src/cli/serve_config.rs
@@ -1,0 +1,16 @@
+use simple3::limits::Limits;
+
+/// Resolved configuration for the `serve` command.
+pub struct ServeConfig {
+    pub host: String,
+    pub port: u16,
+    pub grpc_port: u16,
+    pub autovacuum_interval: u64,
+    pub autovacuum_threshold: f64,
+    pub max_segment_size_mb: u64,
+    pub scrub_interval: u64,
+    pub shutdown_timeout: u64,
+    pub min_disk_free_mb: u64,
+    pub rate_limit_rps: u32,
+    pub limits: Limits,
+}

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -10,6 +10,7 @@ use crate::auth::grpc_auth::{
     check_grpc_access, extract_credentials, extract_credentials_from_metadata,
 };
 use crate::auth::AuthStore;
+use crate::limits::Limits;
 use crate::metrics_util::DurationRecorder;
 use crate::grpc_helpers::{
     bulk_get_header, bulk_get_not_found, bulk_put_one_object, map_io_err, meta_to_proto,
@@ -39,13 +40,15 @@ use proto::*;
 pub struct GrpcService {
     storage: Arc<Storage>,
     auth_store: Option<Arc<AuthStore>>,
+    limits: Limits,
 }
 
 impl GrpcService {
-    pub const fn new(storage: Arc<Storage>, auth_store: Option<Arc<AuthStore>>) -> Self {
+    pub const fn new(storage: Arc<Storage>, auth_store: Option<Arc<AuthStore>>, limits: Limits) -> Self {
         Self {
             storage,
             auth_store,
+            limits,
         }
     }
 
@@ -116,7 +119,7 @@ impl Simple3 for GrpcService {
         let tmp_id = TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let tmp_path = store.bucket_dir().join(format!(".tmp_grpc_{tmp_id:020}"));
 
-        let (etag, size, crc) = match stream_to_tmp(&mut stream, &tmp_path).await {
+        let (etag, size, crc) = match stream_to_tmp(&mut stream, &tmp_path, self.limits.max_object_size).await {
             Ok(result) => result,
             Err(e) => {
                 std::fs::remove_file(&tmp_path).ok();
@@ -401,12 +404,19 @@ impl Simple3 for GrpcService {
         let src_vid = input.source_version_id;
         let ss = Arc::clone(&src_store);
         let dest_key = input.dest_key;
+        let max_obj_size = self.limits.max_object_size;
         let (etag, meta, src_version_id_out, size) = tokio::task::spawn_blocking(move || {
             let src_meta = ss
                 .get_object_or_version(&src_key, src_vid.as_deref())?
                 .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "source object not found"))?;
             if src_meta.is_delete_marker {
                 return Err(io::Error::new(io::ErrorKind::NotFound, "source is a delete marker"));
+            }
+            if max_obj_size > 0 && src_meta.data_length() > max_obj_size {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "EntityTooLarge: source object exceeds max_object_size",
+                ));
             }
 
             let (content_type, user_metadata) = if replace_metadata {
@@ -462,11 +472,12 @@ impl Simple3 for GrpcService {
             Some(input.delimiter)
         };
         #[allow(clippy::cast_sign_loss)]
-        let max_keys = if input.max_keys <= 0 {
+        let max_keys = (if input.max_keys <= 0 {
             1000
         } else {
             input.max_keys as usize
-        };
+        })
+        .min(self.limits.max_list_keys);
         let continuation = if input.continuation_token.is_empty() {
             None
         } else {
@@ -582,6 +593,7 @@ impl Simple3 for GrpcService {
         self.check_auth_meta(&metadata, "s3:PutObject", "arn:s3:::*")?;
         let mut stream = stream;
         let storage = Arc::clone(&self.storage);
+        let max_obj_size = self.limits.max_object_size;
 
         let (tx, rx) = mpsc::channel(8);
 
@@ -620,7 +632,7 @@ impl Simple3 for GrpcService {
                     }
                 };
 
-                match bulk_put_one_object(&init, &mut stream, &store).await {
+                match bulk_put_one_object(&init, &mut stream, &store, max_obj_size).await {
                     Ok((etag, content_md5, size)) => {
                         let resp = BulkPutResponse {
                             key: init.key,
@@ -802,11 +814,12 @@ impl Simple3 for GrpcService {
             Some(input.delimiter)
         };
         #[allow(clippy::cast_sign_loss)]
-        let max_keys = if input.max_keys <= 0 {
+        let max_keys = (if input.max_keys <= 0 {
             1000
         } else {
             input.max_keys as usize
-        };
+        })
+        .min(self.limits.max_list_keys);
         let key_marker = if input.key_marker.is_empty() {
             None
         } else {

--- a/src/grpc_helpers.rs
+++ b/src/grpc_helpers.rs
@@ -26,6 +26,7 @@ pub fn map_io_err(e: io::Error) -> Status {
         io::ErrorKind::NotFound => Status::not_found(e.to_string()),
         io::ErrorKind::AlreadyExists => Status::already_exists(e.to_string()),
         io::ErrorKind::PermissionDenied => Status::permission_denied(e.to_string()),
+        io::ErrorKind::InvalidData => Status::invalid_argument(e.to_string()),
         _ => Status::internal(e.to_string()),
     }
 }

--- a/src/grpc_helpers.rs
+++ b/src/grpc_helpers.rs
@@ -56,9 +56,11 @@ pub fn segments_to_proto(stats: Vec<SegmentStat>) -> Vec<proto::SegmentStat> {
 }
 
 /// Write incoming stream chunks to a temp file, computing MD5 and CRC32C.
+/// When `max_size > 0`, rejects uploads exceeding the limit.
 pub async fn stream_to_tmp(
     stream: &mut Streaming<PutObjectRequest>,
     tmp_path: &std::path::Path,
+    max_size: u64,
 ) -> Result<(String, u64, u32), Status> {
     let mut file =
         std::fs::File::create(tmp_path).map_err(|e| Status::internal(format!("create tmp: {e}")))?;
@@ -79,6 +81,12 @@ pub async fn stream_to_tmp(
         #[allow(clippy::cast_possible_truncation)]
         {
             size += chunk.len() as u64;
+        }
+        if max_size > 0 && size > max_size {
+            std::fs::remove_file(tmp_path).ok();
+            return Err(Status::invalid_argument(format!(
+                "EntityTooLarge: object size {size} exceeds limit {max_size}"
+            )));
         }
     }
     file.flush()
@@ -175,6 +183,7 @@ pub async fn bulk_put_one_object(
     init: &PutObjectInit,
     stream: &mut Streaming<BulkPutRequest>,
     store: &Arc<BucketStore>,
+    max_size: u64,
 ) -> Result<(String, String, u64), Status> {
     let tmp_id = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let tmp_path = store
@@ -208,6 +217,12 @@ pub async fn bulk_put_one_object(
                 #[allow(clippy::cast_possible_truncation)]
                 {
                     size += chunk.len() as u64;
+                }
+                if max_size > 0 && size > max_size {
+                    std::fs::remove_file(&tmp_path).ok();
+                    return Err(Status::invalid_argument(format!(
+                        "EntityTooLarge: object size {size} exceeds limit {max_size}"
+                    )));
                 }
             }
             Some(proto::bulk_put_request::Request::Init(_)) => break,

--- a/src/grpc_helpers.rs
+++ b/src/grpc_helpers.rs
@@ -75,10 +75,6 @@ pub async fn stream_to_tmp(
                 "expected data chunk after init message",
             ));
         };
-        file.write_all(&chunk)
-            .map_err(|e| Status::internal(format!("write tmp: {e}")))?;
-        hasher.update(&chunk);
-        crc = crc32c::crc32c_append(crc, &chunk);
         #[allow(clippy::cast_possible_truncation)]
         {
             size += chunk.len() as u64;
@@ -89,6 +85,10 @@ pub async fn stream_to_tmp(
                 "EntityTooLarge: object size {size} exceeds limit {max_size}"
             )));
         }
+        file.write_all(&chunk)
+            .map_err(|e| Status::internal(format!("write tmp: {e}")))?;
+        hasher.update(&chunk);
+        crc = crc32c::crc32c_append(crc, &chunk);
     }
     file.flush()
         .map_err(|e| Status::internal(format!("flush tmp: {e}")))?;
@@ -209,12 +209,6 @@ pub async fn bulk_put_one_object(
 
         match msg.request {
             Some(proto::bulk_put_request::Request::Data(chunk)) => {
-                if let Err(e) = file.write_all(&chunk) {
-                    std::fs::remove_file(&tmp_path).ok();
-                    return Err(Status::internal(e.to_string()));
-                }
-                hasher.update(&chunk);
-                crc = crc32c::crc32c_append(crc, &chunk);
                 #[allow(clippy::cast_possible_truncation)]
                 {
                     size += chunk.len() as u64;
@@ -225,6 +219,12 @@ pub async fn bulk_put_one_object(
                         "EntityTooLarge: object size {size} exceeds limit {max_size}"
                     )));
                 }
+                if let Err(e) = file.write_all(&chunk) {
+                    std::fs::remove_file(&tmp_path).ok();
+                    return Err(Status::internal(e.to_string()));
+                }
+                hasher.update(&chunk);
+                crc = crc32c::crc32c_append(crc, &chunk);
             }
             Some(proto::bulk_put_request::Request::Init(_)) => break,
             None => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod grpc;
 pub mod grpc_helpers;
+pub mod limits;
 pub mod metrics_util;
 pub mod s3impl;
 pub mod storage;

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1,0 +1,17 @@
+/// Runtime-resolved request limits.
+#[derive(Debug, Clone)]
+pub struct Limits {
+    /// Maximum single-object size in bytes (0 = unlimited).
+    pub max_object_size: u64,
+    /// Maximum keys returned per `ListObjects` / `ListObjectVersions` page.
+    pub max_list_keys: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_object_size: 5 * 1024 * 1024 * 1024, // 5 GB
+            max_list_keys: 1000,
+        }
+    }
+}

--- a/src/s3impl.rs
+++ b/src/s3impl.rs
@@ -511,6 +511,9 @@ impl S3 for SimpleStorage {
             if e.kind() == io::ErrorKind::NotFound {
                 return s3_error!(NoSuchKey);
             }
+            if e.kind() == io::ErrorKind::InvalidData {
+                return s3_error!(EntityTooLarge);
+            }
             tracing::error!("copy_object: {e}");
             s3_error!(e, InternalError)
         })?;
@@ -878,10 +881,14 @@ impl S3 for SimpleStorage {
 
         let body = input.body.ok_or_else(|| s3_error!(IncompleteBody))?;
 
+        let max_size = self.limits.max_object_size;
         let mut data = Vec::new();
         let mut stream = body;
         while let Some(chunk) = stream.try_next().await.map_err(|e| { tracing::error!("upload_part: read body: {e}"); s3_error!(InternalError) })? {
             data.extend_from_slice(&chunk);
+            if max_size > 0 && data.len() as u64 > max_size {
+                return Err(s3_error!(EntityTooLarge));
+            }
         }
 
         metrics::counter!("simple3_bytes_received_total").increment(data.len() as u64);
@@ -946,7 +953,13 @@ impl S3 for SimpleStorage {
             )
         })
         .await
-        .map_err(|e| { tracing::error!("complete_multipart_upload: {e}"); s3_error!(e, InternalError) })?;
+        .map_err(|e| {
+            if e.kind() == io::ErrorKind::InvalidData {
+                return s3_error!(EntityTooLarge);
+            }
+            tracing::error!("complete_multipart_upload: {e}");
+            s3_error!(e, InternalError)
+        })?;
 
         let output = CompleteMultipartUploadOutput {
             bucket: Some(bucket),

--- a/src/s3impl.rs
+++ b/src/s3impl.rs
@@ -74,17 +74,17 @@ async fn stream_body_to_tmp(body: StreamingBlob, tmp_path: &Path, max_size: u64)
     let mut stream = body;
 
     while let Some(chunk) = stream.try_next().await.map_err(|e| { tracing::error!("read request body: {e}"); s3_error!(InternalError) })? {
-        writer
-            .write_all(&chunk)
-            .map_err(|e| { tracing::error!("write tmp file: {e}"); s3_error!(e, InternalError) })?;
-        hasher.update(&chunk);
-        crc = crc32c::crc32c_append(crc, &chunk);
         total_bytes += chunk.len() as u64;
         if max_size > 0 && total_bytes > max_size {
             drop(writer);
             std::fs::remove_file(tmp_path).ok();
             return Err(s3_error!(EntityTooLarge));
         }
+        writer
+            .write_all(&chunk)
+            .map_err(|e| { tracing::error!("write tmp file: {e}"); s3_error!(e, InternalError) })?;
+        hasher.update(&chunk);
+        crc = crc32c::crc32c_append(crc, &chunk);
     }
     writer.flush().map_err(|e| { tracing::error!("flush tmp file: {e}"); s3_error!(e, InternalError) })?;
 

--- a/src/s3impl.rs
+++ b/src/s3impl.rs
@@ -24,6 +24,7 @@ use s3s::dto::{
 };
 use s3s::{s3_error, S3Request, S3Response, S3Result, S3};
 
+use crate::limits::Limits;
 use crate::metrics_util::DurationRecorder;
 use crate::storage::versioning::VersioningState;
 use crate::storage::{BucketStore, Storage};
@@ -45,11 +46,12 @@ where
 
 pub struct SimpleStorage {
     inner: Arc<Storage>,
+    limits: Limits,
 }
 
 impl SimpleStorage {
-    pub const fn new(storage: Arc<Storage>) -> Self {
-        Self { inner: storage }
+    pub const fn new(storage: Arc<Storage>, limits: Limits) -> Self {
+        Self { inner: storage, limits }
     }
 
     fn bucket(&self, name: &str) -> S3Result<Arc<BucketStore>> {
@@ -61,7 +63,8 @@ impl SimpleStorage {
 }
 
 /// Stream request body to a temp file, returning `(md5_hex, crc32c)`.
-async fn stream_body_to_tmp(body: StreamingBlob, tmp_path: &Path) -> S3Result<(String, u32)> {
+/// When `max_size > 0`, aborts with `EntityTooLarge` if the body exceeds the limit.
+async fn stream_body_to_tmp(body: StreamingBlob, tmp_path: &Path, max_size: u64) -> S3Result<(String, u32)> {
     let file = std::fs::File::create(tmp_path)
         .map_err(|e| { tracing::error!("create tmp file: {e}"); s3_error!(e, InternalError) })?;
     let mut writer = io::BufWriter::with_capacity(1024 * 1024, file);
@@ -77,6 +80,11 @@ async fn stream_body_to_tmp(body: StreamingBlob, tmp_path: &Path) -> S3Result<(S
         hasher.update(&chunk);
         crc = crc32c::crc32c_append(crc, &chunk);
         total_bytes += chunk.len() as u64;
+        if max_size > 0 && total_bytes > max_size {
+            drop(writer);
+            std::fs::remove_file(tmp_path).ok();
+            return Err(s3_error!(EntityTooLarge));
+        }
     }
     writer.flush().map_err(|e| { tracing::error!("flush tmp file: {e}"); s3_error!(e, InternalError) })?;
 
@@ -271,7 +279,7 @@ impl S3 for SimpleStorage {
         let tmp_id = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
         let tmp_path = store.bucket_dir().join(format!(".tmp_{tmp_id:020}"));
 
-        let (etag_hex, crc) = match stream_body_to_tmp(body, &tmp_path).await {
+        let (etag_hex, crc) = match stream_body_to_tmp(body, &tmp_path, self.limits.max_object_size).await {
             Ok(v) => v,
             Err(e) => {
                 std::fs::remove_file(&tmp_path).ok();
@@ -469,8 +477,16 @@ impl S3 for SimpleStorage {
         let src_vid = src_version_id.clone();
         let ss = Arc::clone(&src_store);
         let dest_key = input.key;
+        let max_obj_size = self.limits.max_object_size;
         let result = blocking(move || {
             let src_meta = resolve_object_version(&ss, &src_key, src_vid.as_deref())?;
+
+            if max_obj_size > 0 && src_meta.data_length() > max_obj_size {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "EntityTooLarge: source object exceeds max_object_size",
+                ));
+            }
 
             let (content_type, user_metadata) = if replace_metadata {
                 (req_content_type, req_metadata)
@@ -672,7 +688,7 @@ impl S3 for SimpleStorage {
         let store = self.bucket(&input.bucket)?;
 
         #[allow(clippy::cast_sign_loss)] // max(0) guarantees non-negative
-        let max_keys = input.max_keys.unwrap_or(1000).max(0) as usize;
+        let max_keys = (input.max_keys.unwrap_or(1000).max(0) as usize).min(self.limits.max_list_keys);
         let prefix = input.prefix.clone();
         let delimiter = input.delimiter.clone();
         let continuation = input.continuation_token.clone();
@@ -754,7 +770,7 @@ impl S3 for SimpleStorage {
         let store = self.bucket(&input.bucket)?;
 
         #[allow(clippy::cast_sign_loss)]
-        let max_keys = input.max_keys.unwrap_or(1000).max(0) as usize;
+        let max_keys = (input.max_keys.unwrap_or(1000).max(0) as usize).min(self.limits.max_list_keys);
         let prefix = input.prefix.clone();
         let delimiter = input.delimiter.clone();
         let key_marker = input.key_marker.clone();
@@ -917,6 +933,7 @@ impl S3 for SimpleStorage {
         let upload_id = input.upload_id;
         let key = input.key;
         let bucket = input.bucket;
+        let max_obj_size = self.limits.max_object_size;
         let (meta, etag) = blocking(move || {
             store.complete_multipart_upload(
                 &upload_id,
@@ -925,6 +942,7 @@ impl S3 for SimpleStorage {
                 None, // content_type from CreateMultipartUpload not stored yet
                 now,
                 HashMap::new(),
+                max_obj_size,
             )
         })
         .await

--- a/src/storage/multipart.rs
+++ b/src/storage/multipart.rs
@@ -41,7 +41,7 @@ impl BucketStore {
     }
 
     #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::too_many_arguments)] // max_object_size limit added for issue #14
+    #[allow(clippy::too_many_arguments)] // logically-distinct storage params; bundling into a struct adds indirection with no reuse benefit
     pub fn complete_multipart_upload(
         &self,
         upload_id: &str,

--- a/src/storage/multipart.rs
+++ b/src/storage/multipart.rs
@@ -41,6 +41,7 @@ impl BucketStore {
     }
 
     #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::too_many_arguments)] // max_object_size limit added for issue #14
     pub fn complete_multipart_upload(
         &self,
         upload_id: &str,
@@ -49,6 +50,7 @@ impl BucketStore {
         content_type: Option<String>,
         last_modified: u64,
         user_metadata: HashMap<String, String>,
+        max_object_size: u64,
     ) -> io::Result<(ObjectMeta, String)> {
         let mut sorted_parts: Vec<_> = parts.to_vec();
         sorted_parts.sort_by_key(|(num, _)| *num);
@@ -62,6 +64,15 @@ impl BucketStore {
                     .saturating_sub(16))
             })
             .sum::<io::Result<u64>>()?;
+
+        if max_object_size > 0 && total_expected > max_object_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "EntityTooLarge: multipart upload total size {total_expected} exceeds limit {max_object_size}"
+                ),
+            ));
+        }
 
         let mut w = self
             .writer

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -50,7 +50,7 @@ fn build_s3_service(
         }
     };
 
-    let s3 = SimpleStorage::new(Arc::clone(&storage));
+    let s3 = SimpleStorage::new(Arc::clone(&storage), simple3::limits::Limits::default());
     let auth_provider = AuthProvider::new(Arc::clone(&auth_store));
     let mut builder = S3ServiceBuilder::new(s3);
     builder.set_auth(auth_provider.clone());

--- a/tests/crash_recovery_test.rs
+++ b/tests/crash_recovery_test.rs
@@ -224,7 +224,7 @@ fn test_crash_during_multipart_after_commit() {
     let e2 = bucket.upload_part(&upload_id, 2, b"part-two").unwrap();
     let parts = vec![(1, e1), (2, e2)];
     bucket
-        .complete_multipart_upload(&upload_id, "mpu_obj", &parts, None, 1000, HashMap::new())
+        .complete_multipart_upload(&upload_id, "mpu_obj", &parts, None, 1000, HashMap::new(), 0)
         .unwrap();
 
     let bd = bucket.bucket_dir().to_path_buf();

--- a/tests/storage_test.rs
+++ b/tests/storage_test.rs
@@ -489,7 +489,7 @@ fn test_multipart_upload_basic() {
     // Complete
     let parts = vec![(1, etag1), (2, etag2), (3, etag3)];
     let (meta, etag) = bucket
-        .complete_multipart_upload(&upload_id, "multipart_obj", &parts, None, 500, HashMap::new())
+        .complete_multipart_upload(&upload_id, "multipart_obj", &parts, None, 500, HashMap::new(), 0)
         .unwrap();
 
     // ETag has -N suffix
@@ -530,7 +530,7 @@ fn test_multipart_upload_out_of_order() {
 
     let parts = vec![(3, etag3), (1, etag1), (2, etag2)];
     let (meta, _) = bucket
-        .complete_multipart_upload(&upload_id, "ooo", &parts, None, 0, HashMap::new())
+        .complete_multipart_upload(&upload_id, "ooo", &parts, None, 0, HashMap::new(), 0)
         .unwrap();
 
     // Should be sorted by part number
@@ -660,7 +660,7 @@ fn test_multipart_overwrite_compacts() {
     let e1 = bucket.upload_part(&uid, 1, b"AAA").unwrap();
     let e2 = bucket.upload_part(&uid, 2, b"BBB").unwrap();
     let (meta, _) = bucket
-        .complete_multipart_upload(&uid, "key", &[(1, e1), (2, e2)], None, 0, HashMap::new())
+        .complete_multipart_upload(&uid, "key", &[(1, e1), (2, e2)], None, 0, HashMap::new(), 0)
         .unwrap();
 
     // Append-only: 14 + 6+4 = 24, dead_bytes = 14
@@ -963,7 +963,7 @@ fn test_verify_multipart_upload() {
     let etag2 = bucket.upload_part(&upload_id, 2, b"part two").unwrap();
     let parts = vec![(1, etag1), (2, etag2)];
     bucket
-        .complete_multipart_upload(&upload_id, "mpu_obj", &parts, None, 0, HashMap::new())
+        .complete_multipart_upload(&upload_id, "mpu_obj", &parts, None, 0, HashMap::new(), 0)
         .unwrap();
 
     // Verify should pass — content_md5 was set during assembly
@@ -1088,7 +1088,7 @@ fn test_backup_restore_cold_copy() {
     let etag_p2 = bucket.upload_part(&upload_id, 2, b"beta").unwrap();
     let parts = vec![(1, etag_p1), (2, etag_p2)];
     bucket
-        .complete_multipart_upload(&upload_id, "multi.bin", &parts, None, 300, HashMap::new())
+        .complete_multipart_upload(&upload_id, "multi.bin", &parts, None, 300, HashMap::new(), 0)
         .unwrap();
 
     // Drop storage to simulate server stop


### PR DESCRIPTION
## Summary

Closes #14

- Add per-IP token-bucket rate limiting via `governor` crate — configurable `server.rate_limit_rps` (0 = disabled), returns 429/SlowDown (HTTP with `Retry-After`) or gRPC `RESOURCE_EXHAUSTED`
- Enforce `storage.max_object_size` (default 5 GB) on PutObject, UploadPart, CopyObject, CompleteMultipartUpload — rejects with `EntityTooLarge` (HTTP) or `INVALID_ARGUMENT` (gRPC)
- Cap `storage.max_list_keys` (default 1000) on ListObjectsV2 and ListObjectVersions across both S3 HTTP and gRPC
- Refactor `serve::run` from 10 positional args to `ServeConfig` struct
- All limits configurable via TOML `[server]`/`[storage]` sections and CLI flags

## Files changed

| File | Change |
|------|--------|
| `Cargo.toml` | Add `governor` dependency |
| `src/limits.rs` | **New** — `Limits` struct (max_object_size, max_list_keys) |
| `src/cli/serve_config.rs` | **New** — `ServeConfig` struct replacing positional args |
| `src/cli/rate_limit.rs` | **New** — Governor-based per-IP rate limiter + Tower layer for gRPC |
| `src/cli/config.rs` | Add `rate_limit_rps`, `max_object_size_mb`, `max_list_keys` to TOML config |
| `src/cli/mod.rs` | Add CLI args, wire through merge logic with `ServeConfig` |
| `src/cli/serve.rs` | Refactor `run()`, add `PeerIpService`, rate limit check in `AdminService::call`, wire gRPC layer |
| `src/s3impl.rs` | `Limits` in `SimpleStorage`, enforce in `stream_body_to_tmp`, `upload_part`, `copy_object`, list ops |
| `src/storage/multipart.rs` | `max_object_size` check in `complete_multipart_upload` |
| `src/grpc.rs` | `Limits` in `GrpcService`, enforce `max_list_keys` + `max_object_size` in uploads/copies |
| `src/grpc_helpers.rs` | `max_size` param in `stream_to_tmp` + `bulk_put_one_object`, `InvalidData` mapping in `map_io_err` |

## Test plan

- [x] `cargo build` passes
- [x] `cargo lint` passes (clippy pedantic + nursery)
- [x] `cargo test` — all 121 tests pass
- [ ] Manual: `cargo run -- serve --max-object-size-mb 1 --max-list-keys 10 --rate-limit-rps 5`
- [ ] Manual: Upload >1MB object → expect `EntityTooLarge`
- [ ] Manual: ListObjectsV2 with `max-keys=100` → verify capped at 10
- [ ] Manual: Rapid requests → expect 429 with `Retry-After: 1`
- [ ] Manual: `/health` and `/ready` → never rate-limited
- [ ] Manual: `/metrics` → verify `simple3_rate_limited_total` counter