### PR TITLE
fix(s3): stream upload_part to disk instead of buffering in memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3648,6 +3648,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tonic-prost-build = "0.14"
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 testcontainers = "0.27"
+urlencoding = "2"
 
 [[bench]]
 name = "storage_bench"

--- a/src/s3impl.rs
+++ b/src/s3impl.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::io::{self, Write};
+use std::io;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -65,9 +65,9 @@ impl SimpleStorage {
 /// Stream request body to a temp file, returning `(md5_hex, crc32c)`.
 /// When `max_size > 0`, aborts with `EntityTooLarge` if the body exceeds the limit.
 async fn stream_body_to_tmp(body: StreamingBlob, tmp_path: &Path, max_size: u64) -> S3Result<(String, u32)> {
-    let file = std::fs::File::create(tmp_path)
+    let file = tokio::fs::File::create(tmp_path).await
         .map_err(|e| { tracing::error!("create tmp file: {e}"); s3_error!(e, InternalError) })?;
-    let mut writer = io::BufWriter::with_capacity(1024 * 1024, file);
+    let mut writer = tokio::io::BufWriter::with_capacity(1024 * 1024, file);
     let mut hasher = Md5::new();
     let mut crc: u32 = 0;
     let mut total_bytes = 0u64;
@@ -77,16 +77,16 @@ async fn stream_body_to_tmp(body: StreamingBlob, tmp_path: &Path, max_size: u64)
         total_bytes += chunk.len() as u64;
         if max_size > 0 && total_bytes > max_size {
             drop(writer);
-            std::fs::remove_file(tmp_path).ok();
+            tokio::fs::remove_file(tmp_path).await.ok();
             return Err(s3_error!(EntityTooLarge));
         }
-        writer
-            .write_all(&chunk)
+        tokio::io::AsyncWriteExt::write_all(&mut writer, &chunk).await
             .map_err(|e| { tracing::error!("write tmp file: {e}"); s3_error!(e, InternalError) })?;
         hasher.update(&chunk);
         crc = crc32c::crc32c_append(crc, &chunk);
     }
-    writer.flush().map_err(|e| { tracing::error!("flush tmp file: {e}"); s3_error!(e, InternalError) })?;
+    tokio::io::AsyncWriteExt::flush(&mut writer).await
+        .map_err(|e| { tracing::error!("flush tmp file: {e}"); s3_error!(e, InternalError) })?;
 
     metrics::counter!("simple3_bytes_received_total").increment(total_bytes);
     Ok((format!("{:x}", hasher.finalize()), crc))
@@ -282,7 +282,7 @@ impl S3 for SimpleStorage {
         let (etag_hex, crc) = match stream_body_to_tmp(body, &tmp_path, self.limits.max_object_size).await {
             Ok(v) => v,
             Err(e) => {
-                std::fs::remove_file(&tmp_path).ok();
+                tokio::fs::remove_file(&tmp_path).await.ok();
                 return Err(e);
             }
         };
@@ -887,7 +887,7 @@ impl S3 for SimpleStorage {
         let (md5_hex, _crc) = match stream_body_to_tmp(body, &tmp_path, self.limits.max_object_size).await {
             Ok(v) => v,
             Err(e) => {
-                std::fs::remove_file(&tmp_path).ok();
+                tokio::fs::remove_file(&tmp_path).await.ok();
                 return Err(e);
             }
         };

--- a/src/s3impl.rs
+++ b/src/s3impl.rs
@@ -881,21 +881,20 @@ impl S3 for SimpleStorage {
 
         let body = input.body.ok_or_else(|| s3_error!(IncompleteBody))?;
 
-        let max_size = self.limits.max_object_size;
-        let mut data = Vec::new();
-        let mut stream = body;
-        while let Some(chunk) = stream.try_next().await.map_err(|e| { tracing::error!("upload_part: read body: {e}"); s3_error!(InternalError) })? {
-            data.extend_from_slice(&chunk);
-            if max_size > 0 && data.len() as u64 > max_size {
-                return Err(s3_error!(EntityTooLarge));
-            }
-        }
+        let tmp_id = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = store.bucket_dir().join(format!(".tmp_{tmp_id:020}"));
 
-        metrics::counter!("simple3_bytes_received_total").increment(data.len() as u64);
+        let (md5_hex, _crc) = match stream_body_to_tmp(body, &tmp_path, self.limits.max_object_size).await {
+            Ok(v) => v,
+            Err(e) => {
+                std::fs::remove_file(&tmp_path).ok();
+                return Err(e);
+            }
+        };
 
         let upload_id = input.upload_id;
         let part_number = input.part_number;
-        let etag = blocking(move || store.upload_part(&upload_id, part_number, &data))
+        let etag = blocking(move || store.upload_part(&upload_id, part_number, &tmp_path, &md5_hex))
             .await
             .map_err(|e| { tracing::error!("upload_part: {e}"); s3_error!(e, InternalError) })?;
 

--- a/src/storage/multipart.rs
+++ b/src/storage/multipart.rs
@@ -30,6 +30,9 @@ impl BucketStore {
     /// Store a part from a temp file that was streamed to disk.
     /// `md5_hex` is the pre-computed MD5 hex string (from streaming).
     /// The part file stores [data][16-byte raw MD5] for assembly.
+    /// Appends the digest to the temp file first, then atomically renames
+    /// to the final `.mpu_*` path so `complete_multipart_upload` only sees
+    /// fully-written parts.
     pub fn upload_part(
         &self,
         upload_id: &str,
@@ -37,11 +40,13 @@ impl BucketStore {
         tmp_path: &Path,
         md5_hex: &str,
     ) -> io::Result<String> {
+        let digest = md5_hex_to_bytes(md5_hex)?;
+        {
+            let mut f = OpenOptions::new().append(true).open(tmp_path)?;
+            f.write_all(&digest)?;
+        }
         let part_path = self.part_path(upload_id, part_number);
         fs::rename(tmp_path, &part_path)?;
-        let mut f = OpenOptions::new().append(true).open(&part_path)?;
-        let digest = md5_hex_to_bytes(md5_hex)?;
-        f.write_all(&digest)?;
         Ok(md5_hex.to_owned())
     }
 

--- a/src/storage/multipart.rs
+++ b/src/storage/multipart.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
-use std::fs::{self, File};
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use md5::{Digest, Md5};
@@ -27,17 +27,22 @@ impl BucketStore {
             .join(format!(".mpu_{upload_id}_{part_num:05}"))
     }
 
+    /// Store a part from a temp file that was streamed to disk.
+    /// `md5_hex` is the pre-computed MD5 hex string (from streaming).
+    /// The part file stores [data][16-byte raw MD5] for assembly.
     pub fn upload_part(
         &self,
         upload_id: &str,
         part_number: i32,
-        data: &[u8],
+        tmp_path: &Path,
+        md5_hex: &str,
     ) -> io::Result<String> {
-        let digest = Md5::digest(data);
-        let mut f = File::create(self.part_path(upload_id, part_number))?;
-        f.write_all(data)?;
+        let part_path = self.part_path(upload_id, part_number);
+        fs::rename(tmp_path, &part_path)?;
+        let mut f = OpenOptions::new().append(true).open(&part_path)?;
+        let digest = md5_hex_to_bytes(md5_hex)?;
         f.write_all(&digest)?;
-        Ok(format!("{digest:x}"))
+        Ok(md5_hex.to_owned())
     }
 
     #[allow(clippy::cast_possible_truncation)]
@@ -198,4 +203,21 @@ impl BucketStore {
         }
         Ok(())
     }
+}
+
+/// Parse a 32-char hex MD5 string into 16 raw bytes.
+fn md5_hex_to_bytes(hex: &str) -> io::Result<[u8; 16]> {
+    let mut out = [0u8; 16];
+    if hex.len() != 32 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("expected 32-char MD5 hex, got {}", hex.len()),
+        ));
+    }
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).map_err(|e| {
+            io::Error::new(io::ErrorKind::InvalidData, format!("invalid MD5 hex: {e}"))
+        })?;
+    }
+    Ok(out)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,10 @@
 // Included by multiple test binaries; not all items used by each.
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use md5::Digest;
 
 use aws_sdk_s3::config::{Credentials, Region, RequestChecksumCalculation};
 use hyper_util::rt::TokioIo;
@@ -141,6 +144,25 @@ pub fn container_host() -> &'static str {
     } else {
         "host.docker.internal"
     }
+}
+
+static TEST_TMP: AtomicU64 = AtomicU64::new(0);
+
+/// Write data to a temp file and upload as a multipart part.
+/// Shared helper used by storage_test and crash_recovery_test.
+pub fn write_part(
+    bucket: &simple3::storage::BucketStore,
+    upload_id: &str,
+    part_number: i32,
+    data: &[u8],
+) -> String {
+    let id = TEST_TMP.fetch_add(1, Ordering::Relaxed);
+    let tmp = bucket.bucket_dir().join(format!(".tmp_test_{id}"));
+    std::fs::write(&tmp, data).unwrap();
+    let md5_hex = format!("{:x}", md5::Md5::digest(data));
+    bucket
+        .upload_part(upload_id, part_number, &tmp, &md5_hex)
+        .unwrap()
 }
 
 pub fn make_client(port: u16, access_key: &str, secret_key: &str) -> aws_sdk_s3::Client {

--- a/tests/copy_object_test.rs
+++ b/tests/copy_object_test.rs
@@ -326,3 +326,46 @@ async fn test_copy_special_chars_key() {
     let data = get.body.collect().await.unwrap().into_bytes();
     assert_eq!(&data[..], body);
 }
+
+/// Regression test: keys containing characters that require percent-encoding
+/// (?, #, %) must round-trip through CopyObject correctly. The s3s library
+/// decodes these at parse time; this test guards against regressions.
+#[tokio::test]
+async fn test_copy_percent_encoded_chars_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let srv = start_server(dir.path()).await;
+    let client = make_client(srv.port, &srv.access_key, &srv.secret_key);
+
+    client.create_bucket().bucket("test").send().await.unwrap();
+
+    let body = b"percent encoded data";
+    let key = "docs/file?version=2#section&tag=100%done.txt";
+
+    client
+        .put_object()
+        .bucket("test")
+        .key(key)
+        .body(ByteStream::from_static(body))
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .copy_object()
+        .bucket("test")
+        .key("backup/encoded-copy.txt")
+        .copy_source(format!("test/{key}"))
+        .send()
+        .await
+        .unwrap();
+
+    let get = client
+        .get_object()
+        .bucket("test")
+        .key("backup/encoded-copy.txt")
+        .send()
+        .await
+        .unwrap();
+    let data = get.body.collect().await.unwrap().into_bytes();
+    assert_eq!(&data[..], body);
+}

--- a/tests/copy_object_test.rs
+++ b/tests/copy_object_test.rs
@@ -354,7 +354,7 @@ async fn test_copy_percent_encoded_chars_key() {
         .copy_object()
         .bucket("test")
         .key("backup/encoded-copy.txt")
-        .copy_source(format!("test/{key}"))
+        .copy_source(format!("test/{}", urlencoding::encode(key)))
         .send()
         .await
         .unwrap();

--- a/tests/crash_recovery_test.rs
+++ b/tests/crash_recovery_test.rs
@@ -2,11 +2,22 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use md5::{Digest, Md5};
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
-use simple3::storage::Storage;
+use simple3::storage::{BucketStore, Storage};
 use simple3::types::ObjectMeta;
+
+static TEST_TMP: AtomicU64 = AtomicU64::new(0);
+
+fn write_part(bucket: &BucketStore, upload_id: &str, part_number: i32, data: &[u8]) -> String {
+    let id = TEST_TMP.fetch_add(1, Ordering::Relaxed);
+    let tmp = bucket.bucket_dir().join(format!(".tmp_test_{id}"));
+    fs::write(&tmp, data).unwrap();
+    let md5_hex = format!("{:x}", Md5::digest(data));
+    bucket.upload_part(upload_id, part_number, &tmp, &md5_hex).unwrap()
+}
 
 const OBJECTS: TableDefinition<&str, &[u8]> = TableDefinition::new("objects");
 const SEG_COMPACTING: TableDefinition<u32, u8> = TableDefinition::new("seg_compacting");
@@ -173,8 +184,8 @@ fn test_crash_during_multipart_before_commit() {
 
     // Start multipart but don't complete
     let upload_id = bucket.create_multipart_upload();
-    bucket.upload_part(&upload_id, 1, b"part-one-").unwrap();
-    bucket.upload_part(&upload_id, 2, b"part-two").unwrap();
+    write_part(&bucket, &upload_id, 1, b"part-one-");
+    write_part(&bucket, &upload_id, 2, b"part-two");
 
     let bd = bucket.bucket_dir().to_path_buf();
     drop(bucket);
@@ -220,8 +231,8 @@ fn test_crash_during_multipart_after_commit() {
     let bucket = storage.get_bucket("b").unwrap().unwrap();
 
     let upload_id = bucket.create_multipart_upload();
-    let e1 = bucket.upload_part(&upload_id, 1, b"part-one-").unwrap();
-    let e2 = bucket.upload_part(&upload_id, 2, b"part-two").unwrap();
+    let e1 = write_part(&bucket, &upload_id, 1, b"part-one-");
+    let e2 = write_part(&bucket, &upload_id, 2, b"part-two");
     let parts = vec![(1, e1), (2, e2)];
     bucket
         .complete_multipart_upload(&upload_id, "mpu_obj", &parts, None, 1000, HashMap::new(), 0)

--- a/tests/crash_recovery_test.rs
+++ b/tests/crash_recovery_test.rs
@@ -1,23 +1,15 @@
+mod common;
+use common::write_part;
+
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use md5::{Digest, Md5};
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
-use simple3::storage::{BucketStore, Storage};
+use simple3::storage::Storage;
 use simple3::types::ObjectMeta;
-
-static TEST_TMP: AtomicU64 = AtomicU64::new(0);
-
-fn write_part(bucket: &BucketStore, upload_id: &str, part_number: i32, data: &[u8]) -> String {
-    let id = TEST_TMP.fetch_add(1, Ordering::Relaxed);
-    let tmp = bucket.bucket_dir().join(format!(".tmp_test_{id}"));
-    fs::write(&tmp, data).unwrap();
-    let md5_hex = format!("{:x}", Md5::digest(data));
-    bucket.upload_part(upload_id, part_number, &tmp, &md5_hex).unwrap()
-}
 
 const OBJECTS: TableDefinition<&str, &[u8]> = TableDefinition::new("objects");
 const SEG_COMPACTING: TableDefinition<u32, u8> = TableDefinition::new("seg_compacting");

--- a/tests/storage_test.rs
+++ b/tests/storage_test.rs
@@ -1,9 +1,20 @@
 use md5::{Digest, Md5};
-use simple3::storage::Storage;
+use simple3::storage::{BucketStore, Storage};
 use simple3::types::ObjectMeta;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::{Seek, SeekFrom, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEST_TMP: AtomicU64 = AtomicU64::new(0);
+
+fn write_part(bucket: &BucketStore, upload_id: &str, part_number: i32, data: &[u8]) -> String {
+    let id = TEST_TMP.fetch_add(1, Ordering::Relaxed);
+    let tmp = bucket.bucket_dir().join(format!(".tmp_test_{id}"));
+    std::fs::write(&tmp, data).unwrap();
+    let md5_hex = format!("{:x}", Md5::digest(data));
+    bucket.upload_part(upload_id, part_number, &tmp, &md5_hex).unwrap()
+}
 
 fn make_meta(segment_id: u32, offset: u64, length: u64, etag: &str, crc: u32) -> ObjectMeta {
     ObjectMeta {
@@ -482,9 +493,9 @@ fn test_multipart_upload_basic() {
     assert!(!upload_id.is_empty());
 
     // Upload 3 parts
-    let etag1 = bucket.upload_part(&upload_id, 1, b"AAAA").unwrap();
-    let etag2 = bucket.upload_part(&upload_id, 2, b"BBBB").unwrap();
-    let etag3 = bucket.upload_part(&upload_id, 3, b"CCCC").unwrap();
+    let etag1 = write_part(&bucket, &upload_id, 1, b"AAAA");
+    let etag2 = write_part(&bucket, &upload_id, 2, b"BBBB");
+    let etag3 = write_part(&bucket, &upload_id, 3, b"CCCC");
 
     // Complete
     let parts = vec![(1, etag1), (2, etag2), (3, etag3)];
@@ -524,9 +535,9 @@ fn test_multipart_upload_out_of_order() {
     let upload_id = bucket.create_multipart_upload();
 
     // Upload parts out of order
-    let etag3 = bucket.upload_part(&upload_id, 3, b"CCC").unwrap();
-    let etag1 = bucket.upload_part(&upload_id, 1, b"AAA").unwrap();
-    let etag2 = bucket.upload_part(&upload_id, 2, b"BBB").unwrap();
+    let etag3 = write_part(&bucket, &upload_id, 3, b"CCC");
+    let etag1 = write_part(&bucket, &upload_id, 1, b"AAA");
+    let etag2 = write_part(&bucket, &upload_id, 2, b"BBB");
 
     let parts = vec![(3, etag3), (1, etag1), (2, etag2)];
     let (meta, _) = bucket
@@ -546,8 +557,8 @@ fn test_abort_multipart_upload() {
     let bucket = storage.get_bucket("b").unwrap().unwrap();
 
     let upload_id = bucket.create_multipart_upload();
-    bucket.upload_part(&upload_id, 1, b"data").unwrap();
-    bucket.upload_part(&upload_id, 2, b"more").unwrap();
+    write_part(&bucket, &upload_id, 1, b"data");
+    write_part(&bucket, &upload_id, 2, b"more");
 
     // Part files exist
     let bucket_dir = dir.path().join("b");
@@ -657,8 +668,8 @@ fn test_multipart_overwrite_compacts() {
 
     // Overwrite via multipart: 6 bytes data total (append-only: file grows)
     let uid = bucket.create_multipart_upload();
-    let e1 = bucket.upload_part(&uid, 1, b"AAA").unwrap();
-    let e2 = bucket.upload_part(&uid, 2, b"BBB").unwrap();
+    let e1 = write_part(&bucket, &uid, 1, b"AAA");
+    let e2 = write_part(&bucket, &uid, 2, b"BBB");
     let (meta, _) = bucket
         .complete_multipart_upload(&uid, "key", &[(1, e1), (2, e2)], None, 0, HashMap::new(), 0)
         .unwrap();
@@ -959,8 +970,8 @@ fn test_verify_multipart_upload() {
     let bucket = storage.get_bucket("b").unwrap().unwrap();
 
     let upload_id = bucket.create_multipart_upload();
-    let etag1 = bucket.upload_part(&upload_id, 1, b"part one ").unwrap();
-    let etag2 = bucket.upload_part(&upload_id, 2, b"part two").unwrap();
+    let etag1 = write_part(&bucket, &upload_id, 1, b"part one ");
+    let etag2 = write_part(&bucket, &upload_id, 2, b"part two");
     let parts = vec![(1, etag1), (2, etag2)];
     bucket
         .complete_multipart_upload(&upload_id, "mpu_obj", &parts, None, 0, HashMap::new(), 0)
@@ -1084,8 +1095,8 @@ fn test_backup_restore_cold_copy() {
 
     // 3) Multipart upload
     let upload_id = bucket.create_multipart_upload();
-    let etag_p1 = bucket.upload_part(&upload_id, 1, b"alpha-").unwrap();
-    let etag_p2 = bucket.upload_part(&upload_id, 2, b"beta").unwrap();
+    let etag_p1 = write_part(&bucket, &upload_id, 1, b"alpha-");
+    let etag_p2 = write_part(&bucket, &upload_id, 2, b"beta");
     let parts = vec![(1, etag_p1), (2, etag_p2)];
     bucket
         .complete_multipart_upload(&upload_id, "multi.bin", &parts, None, 300, HashMap::new(), 0)

--- a/tests/storage_test.rs
+++ b/tests/storage_test.rs
@@ -1,20 +1,12 @@
+mod common;
+use common::write_part;
+
 use md5::{Digest, Md5};
-use simple3::storage::{BucketStore, Storage};
+use simple3::storage::Storage;
 use simple3::types::ObjectMeta;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::{Seek, SeekFrom, Write};
-use std::sync::atomic::{AtomicU64, Ordering};
-
-static TEST_TMP: AtomicU64 = AtomicU64::new(0);
-
-fn write_part(bucket: &BucketStore, upload_id: &str, part_number: i32, data: &[u8]) -> String {
-    let id = TEST_TMP.fetch_add(1, Ordering::Relaxed);
-    let tmp = bucket.bucket_dir().join(format!(".tmp_test_{id}"));
-    std::fs::write(&tmp, data).unwrap();
-    let md5_hex = format!("{:x}", Md5::digest(data));
-    bucket.upload_part(upload_id, part_number, &tmp, &md5_hex).unwrap()
-}
 
 fn make_meta(segment_id: u32, offset: u64, length: u64, etag: &str, crc: u32) -> ObjectMeta {
     ObjectMeta {


### PR DESCRIPTION
## Summary
- **SIMPLE-29**: `upload_part` previously buffered entire part body (up to 5 GB) into a `Vec<u8>` in memory. Now streams to a temp file via `stream_body_to_tmp()` with incremental MD5/CRC32C hashing, then renames into the `.mpu_` part file. Storage layer `upload_part()` accepts a file path + pre-computed MD5 hex instead of `&[u8]`.
- **SIMPLE-30**: Confirmed as not-a-bug — s3s v0.13.0 already fully URL-decodes `CopySource` at parse time. Added regression test with `?`, `#`, `%` characters.

Closes SIMPLE-26, SIMPLE-29, SIMPLE-30

## Test plan
- [x] All 104 existing tests pass
- [x] `cargo lint` clean
- [x] New `test_copy_percent_encoded_chars_key` regression test added
- [x] Multipart storage tests exercise the new streaming path