### PR TITLE
fix(s3,storage): quality improvements from PR review audit (#27)

### DIFF
--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -152,24 +152,23 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
         );
 
         // Rate limit check (exempt health/ready/metrics endpoints)
-        let rate_limited = {
-            let p = req.uri().path();
-            p != "/health"
-                && p != "/ready"
-                && p != "/metrics"
-                && self.rate_limiter.as_ref().is_some_and(|limiter| {
-                    let peer_ip = req
-                        .extensions()
-                        .get::<std::net::IpAddr>()
-                        .copied()
-                        .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
-                    limiter.check_key(&peer_ip).is_err()
-                })
-        };
+        let path = req.uri().path();
+        let rate_limited = path != "/health"
+            && path != "/ready"
+            && path != "/metrics"
+            && self.rate_limiter.as_ref().is_some_and(|limiter| {
+                let peer_ip = req
+                    .extensions()
+                    .get::<std::net::IpAddr>()
+                    .copied()
+                    .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+                limiter.check_key(&peer_ip).is_err()
+            });
+        let is_admin = path.starts_with("/_/");
 
         let fut: ServiceFuture = if rate_limited {
             metrics::counter!("simple3_rate_limited_total", "protocol" => "http").increment(1);
-            if req.uri().path().starts_with("/_/") {
+            if is_admin {
                 // Admin endpoints use JSON
                 Box::pin(async {
                     let mut resp = json_response(
@@ -182,15 +181,15 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
                 })
             } else {
                 // S3 endpoints use XML
+                static RATE_LIMIT_XML: &[u8] = b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+                    <Error><Code>SlowDown</Code>\
+                    <Message>Rate limit exceeded</Message></Error>";
                 Box::pin(async {
                     Ok(hyper::Response::builder()
                         .status(429)
                         .header("content-type", "application/xml")
                         .header("retry-after", "1")
-                        .body(s3s::Body::from(bytes::Bytes::from_static(
-                            b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-                            <Error><Code>SlowDown</Code>\
-                            <Message>Rate limit exceeded</Message></Error>")))
+                        .body(s3s::Body::from(bytes::Bytes::from_static(RATE_LIMIT_XML)))
                         .unwrap_or_else(|e| json_response(
                             500,
                             &serde_json::json!({"error": format!("rate limit response: {e}")}),
@@ -198,7 +197,7 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
                 })
             }
         } else {
-            let path = req.uri().path().to_owned();
+            let path = path.to_owned();
             self.dispatch(req, &method, &path)
         };
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -144,34 +144,36 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
     fn call(&self, req: hyper::Request<hyper::body::Incoming>) -> Self::Future {
         let request_id = super::request_id::generate_request_id();
         let method = req.method().clone();
-        let path = req.uri().path().to_owned();
         let span = tracing::info_span!(
             "http_request",
             request_id = %request_id,
             method = %method,
-            path = %path,
+            path = %req.uri().path(),
         );
 
         // Rate limit check (exempt health/ready/metrics endpoints)
-        let rate_limited = path != "/health"
-            && path != "/ready"
-            && path != "/metrics"
-            && self.rate_limiter.as_ref().is_some_and(|limiter| {
-                let peer_ip = req
-                    .extensions()
-                    .get::<std::net::IpAddr>()
-                    .copied()
-                    .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
-                limiter.check_key(&peer_ip).is_err()
-            });
+        let rate_limited = {
+            let p = req.uri().path();
+            p != "/health"
+                && p != "/ready"
+                && p != "/metrics"
+                && self.rate_limiter.as_ref().is_some_and(|limiter| {
+                    let peer_ip = req
+                        .extensions()
+                        .get::<std::net::IpAddr>()
+                        .copied()
+                        .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+                    limiter.check_key(&peer_ip).is_err()
+                })
+        };
 
         let fut: ServiceFuture = if rate_limited {
             metrics::counter!("simple3_rate_limited_total", "protocol" => "http").increment(1);
-            if path.starts_with("/_/") {
+            if req.uri().path().starts_with("/_/") {
                 // Admin endpoints use JSON
                 Box::pin(async {
                     let mut resp = json_response(
-                        503,
+                        429,
                         &serde_json::json!({"error": "SlowDown", "message": "Rate limit exceeded"}),
                     );
                     resp.headers_mut()
@@ -180,16 +182,15 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
                 })
             } else {
                 // S3 endpoints use XML
-                let body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-                    <Error><Code>SlowDown</Code>\
-                    <Message>Rate limit exceeded</Message></Error>"
-                    .to_owned();
                 Box::pin(async {
                     Ok(hyper::Response::builder()
-                        .status(503)
+                        .status(429)
                         .header("content-type", "application/xml")
                         .header("retry-after", "1")
-                        .body(s3s::Body::from(body))
+                        .body(s3s::Body::from(bytes::Bytes::from_static(
+                            b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+                            <Error><Code>SlowDown</Code>\
+                            <Message>Rate limit exceeded</Message></Error>")))
                         .unwrap_or_else(|e| json_response(
                             500,
                             &serde_json::json!({"error": format!("rate limit response: {e}")}),
@@ -197,6 +198,7 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for AdminSer
                 })
             }
         } else {
+            let path = req.uri().path().to_owned();
             self.dispatch(req, &method, &path)
         };
 

--- a/src/storage/compaction.rs
+++ b/src/storage/compaction.rs
@@ -34,33 +34,11 @@ impl BucketStore {
         let mut live = Vec::new();
         let txn = self.db.begin_read().map_err(io::Error::other)?;
 
-        // Scan objects table
-        let table = txn.open_table(OBJECTS).map_err(io::Error::other)?;
-        for result in table.iter().map_err(io::Error::other)? {
-            let (k, v) = result.map_err(io::Error::other)?;
-            let obj = ObjectMeta::from_bytes(v.value()).map_err(io::Error::other)?;
-            if obj.segment_id == segment_id && !obj.is_delete_marker {
-                live.push(LiveEntry {
-                    source: TableSource::Objects,
-                    redb_key: k.value().to_owned(),
-                    meta: obj,
-                });
-            }
-        }
+        let obj_table = txn.open_table(OBJECTS).map_err(io::Error::other)?;
+        collect_from_table(&obj_table, segment_id, TableSource::Objects, &mut live)?;
 
-        // Scan versions table
         let ver_table = txn.open_table(VERSIONS).map_err(io::Error::other)?;
-        for result in ver_table.iter().map_err(io::Error::other)? {
-            let (k, v) = result.map_err(io::Error::other)?;
-            let obj = ObjectMeta::from_bytes(v.value()).map_err(io::Error::other)?;
-            if obj.segment_id == segment_id && !obj.is_delete_marker {
-                live.push(LiveEntry {
-                    source: TableSource::Versions,
-                    redb_key: k.value().to_owned(),
-                    meta: obj,
-                });
-            }
-        }
+        collect_from_table(&ver_table, segment_id, TableSource::Versions, &mut live)?;
 
         live.sort_by_key(|e| e.meta.offset);
         Ok(live)
@@ -89,18 +67,13 @@ impl BucketStore {
                 obj.offset = new_offset;
                 new_offset += obj.length;
                 let bytes = bincode::serialize(&obj).map_err(io::Error::other)?;
-                match entry.source {
-                    TableSource::Objects => {
-                        obj_table
-                            .insert(entry.redb_key.as_str(), bytes.as_slice())
-                            .map_err(io::Error::other)?;
-                    }
-                    TableSource::Versions => {
-                        ver_table
-                            .insert(entry.redb_key.as_str(), bytes.as_slice())
-                            .map_err(io::Error::other)?;
-                    }
-                }
+                let table = match entry.source {
+                    TableSource::Objects => &mut obj_table,
+                    TableSource::Versions => &mut ver_table,
+                };
+                table
+                    .insert(entry.redb_key.as_str(), bytes.as_slice())
+                    .map_err(io::Error::other)?;
             }
         }
 
@@ -282,6 +255,27 @@ fn copy_live_objects(
     drop(tmp);
 
     Ok(entries)
+}
+
+/// Collect live (non-delete-marker) entries from a single redb table for the given segment.
+fn collect_from_table(
+    table: &impl ReadableTable<&'static str, &'static [u8]>,
+    segment_id: u32,
+    source: TableSource,
+    live: &mut Vec<LiveEntry>,
+) -> io::Result<()> {
+    for result in table.iter().map_err(io::Error::other)? {
+        let (k, v) = result.map_err(io::Error::other)?;
+        let obj = ObjectMeta::from_bytes(v.value()).map_err(io::Error::other)?;
+        if obj.segment_id == segment_id && !obj.is_delete_marker {
+            live.push(LiveEntry {
+                source,
+                redb_key: k.value().to_owned(),
+                meta: obj,
+            });
+        }
+    }
+    Ok(())
 }
 
 /// Update a single compacted entry in its table. Returns stale bytes if the

--- a/tests/storage_test.rs
+++ b/tests/storage_test.rs
@@ -97,6 +97,7 @@ fn test_put_get_object() {
     assert_eq!(got.offset, offset);
     assert_eq!(got.data_length(), data.len() as u64);
     assert_eq!(got.etag, "abc123");
+    assert_eq!(got.content_crc32c, Some(crc));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements all 4 subtasks from [SIMPLE-27](https://linear.app/nixcode/issue/SIMPLE-27):

- **SIMPLE-31**: Return HTTP 429 (Too Many Requests) instead of 503 for rate-limited responses. `Retry-After` header was already present.
- **SIMPLE-32**: Avoid unnecessary `String` allocation on `req.uri().path()` in the HTTP request hot path. Path is now borrowed directly for span creation and rate limit checks; allocation deferred to the dispatch branch only. Also eliminates `.to_owned()` on the static XML body string.
- **SIMPLE-33**: Extract `collect_from_table` helper for scanning redb tables during compaction, and simplify `recover_segment_compaction` with table-dispatch pattern (matching `apply_compaction`'s existing clean pattern).
- **SIMPLE-34**: Add `assert_eq!(got.content_crc32c, Some(crc))` to `test_put_get_object` to verify CRC32C metadata survives the redb round-trip.

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo lint` passes (clippy pedantic + nursery)
- [x] `cargo test` — all 149 tests pass
- [x] `test_put_get_object` now asserts CRC32C persistence