### PR TITLE
fix: code health improvements from PR review audit (SIMPLE-28)

### DIFF
--- a/.github/workflows/compat-mint.yml
+++ b/.github/workflows/compat-mint.yml
@@ -28,7 +28,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Pull Mint image
-        run: docker pull minio/mint:edge
+        run: docker pull minio/mint:edge@sha256:08a05e68893c68be2a83b6f79556853ed6aa3c6c9e64c823a00853e4e55d2200
 
       - name: Run Mint compatibility tests
         run: cargo test --test s3_compat compat_mint -- --ignored --nocapture

--- a/benches/storage_bench.rs
+++ b/benches/storage_bench.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 const KB: usize = 1024;
 const MB: usize = 1024 * KB;
 
-fn make_meta(segment_id: u32, offset: u64, length: u64) -> ObjectMeta {
+fn make_meta(segment_id: u32, offset: u64, length: u64, crc: u32) -> ObjectMeta {
     ObjectMeta {
         segment_id,
         offset,
@@ -21,7 +21,7 @@ fn make_meta(segment_id: u32, offset: u64, length: u64) -> ObjectMeta {
         last_modified: 0,
         user_metadata: HashMap::new(),
         content_md5: None,
-        content_crc32c: None,
+        content_crc32c: Some(crc),
         version_id: None,
         is_delete_marker: false,
     }
@@ -41,8 +41,9 @@ fn prefill(storage: &Storage, bucket: &str, count: usize, obj_size: usize) -> Ve
     let mut keys = Vec::with_capacity(count);
     for i in 0..count {
         let key = format!("key{i:06}");
-        let (seg, off, len) = b.append_data(&data).unwrap();
-        b.put_meta(&key, &make_meta(seg, off, len)).unwrap();
+        let (seg, off, len, crc) = b.append_data(&data).unwrap();
+        let mut meta = make_meta(seg, off, len, crc);
+        b.put_meta(&key, &mut meta).unwrap();
         keys.push(key);
     }
     keys
@@ -95,8 +96,9 @@ fn bench_put(c: &mut Criterion) {
             b.iter(|| {
                 let i = counter.fetch_add(1, Ordering::Relaxed);
                 let key = format!("k{i}");
-                let (seg, off, len) = bucket.append_data(&data).unwrap();
-                bucket.put_meta(&key, &make_meta(seg, off, len)).unwrap();
+                let (seg, off, len, crc) = bucket.append_data(&data).unwrap();
+                let mut meta = make_meta(seg, off, len, crc);
+                bucket.put_meta(&key, &mut meta).unwrap();
             });
         });
     }
@@ -218,8 +220,9 @@ fn bench_overwrite(c: &mut Criterion) {
             b.iter(|| {
                 let key = &keys[idx % keys.len()];
                 idx = idx.wrapping_add(7919);
-                let (seg, off, len) = bucket.append_data(&data).unwrap();
-                bucket.put_meta(key, &make_meta(seg, off, len)).unwrap();
+                let (seg, off, len, crc) = bucket.append_data(&data).unwrap();
+                let mut meta = make_meta(seg, off, len, crc);
+                bucket.put_meta(key, &mut meta).unwrap();
             });
         });
     }
@@ -356,10 +359,9 @@ fn bench_concurrent(c: &mut Criterion) {
                             s.spawn(move || {
                                 for i in 0..ops {
                                     let key = format!("t{t}k{i}");
-                                    let (seg, off, len) = bucket.append_data(data).unwrap();
-                                    bucket
-                                        .put_meta(&key, &make_meta(seg, off, len))
-                                        .unwrap();
+                                    let (seg, off, len, crc) = bucket.append_data(data).unwrap();
+                                    let mut meta = make_meta(seg, off, len, crc);
+                                    bucket.put_meta(&key, &mut meta).unwrap();
                                 }
                             });
                         }
@@ -388,10 +390,9 @@ fn bench_concurrent(c: &mut Criterion) {
                             s.spawn(move || {
                                 for i in 0..ops {
                                     let key = format!("t{t}k{i}");
-                                    let (seg, off, len) = bucket.append_data(data).unwrap();
-                                    bucket
-                                        .put_meta(&key, &make_meta(seg, off, len))
-                                        .unwrap();
+                                    let (seg, off, len, crc) = bucket.append_data(data).unwrap();
+                                    let mut meta = make_meta(seg, off, len, crc);
+                                    bucket.put_meta(&key, &mut meta).unwrap();
                                 }
                             });
                         }
@@ -439,10 +440,9 @@ fn bench_concurrent(c: &mut Criterion) {
                             s.spawn(move || {
                                 for i in 0..ops {
                                     let key = format!("new_t{t}k{i}");
-                                    let (seg, off, len) = bucket.append_data(data).unwrap();
-                                    bucket
-                                        .put_meta(&key, &make_meta(seg, off, len))
-                                        .unwrap();
+                                    let (seg, off, len, crc) = bucket.append_data(data).unwrap();
+                                    let mut meta = make_meta(seg, off, len, crc);
+                                    bucket.put_meta(&key, &mut meta).unwrap();
                                 }
                             });
                         }
@@ -490,10 +490,9 @@ fn bench_concurrent(c: &mut Criterion) {
                             s.spawn(move || {
                                 for i in 0..ops {
                                     let key = format!("new_t{t}k{i}");
-                                    let (seg, off, len) = bucket.append_data(data).unwrap();
-                                    bucket
-                                        .put_meta(&key, &make_meta(seg, off, len))
-                                        .unwrap();
+                                    let (seg, off, len, crc) = bucket.append_data(data).unwrap();
+                                    let mut meta = make_meta(seg, off, len, crc);
+                                    bucket.put_meta(&key, &mut meta).unwrap();
                                 }
                             });
                         }

--- a/docker/ceph-s3-tests/Dockerfile
+++ b/docker/ceph-s3-tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-ARG S3_TESTS_REF=master
+ARG S3_TESTS_REF=06e2c5789a39991eed6008b8f728914fe7c7ee3a
 ARG TOX_VERSION=4.25.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -12,6 +12,7 @@ RUN git clone https://github.com/ceph/s3-tests.git /s3-tests && \
 
 WORKDIR /s3-tests
 RUN pip install --no-cache-dir "tox==${TOX_VERSION}"
+RUN tox --notest -e py
 
 RUN useradd --create-home --uid 10001 s3tests && \
     chown -R s3tests:s3tests /s3-tests

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -85,8 +85,9 @@ simple3 --data-dir /path/to/data_dir verify
 For every stored object:
 - Reads the full data from the segment file
 - Computes MD5 and compares against stored `content_md5` / ETag
-- If CRC32C metadata is present:
-  - Computes CRC32C and compares against stored `content_crc32c`
-  - Reads the on-disk CRC trailer and compares against the expected value
 
-Objects written before CRC32C support was added are verified using MD5 only. A clean verify means every object passed all applicable checks.
+**CRC32C checks are per-object optional.** They are only performed when the object has `content_crc32c` metadata — i.e., objects uploaded after CRC32C support was added. If `content_crc32c` is present, verify also:
+- Computes CRC32C over the data and compares against stored `content_crc32c`
+- Reads the on-disk CRC trailer and compares against the expected value
+
+Objects written before CRC32C support was added have no `content_crc32c` metadata and are verified using MD5 only. A clean verify means every object passed all applicable checks.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,6 +15,7 @@ pub mod keys;
 pub mod policy_cmd;
 pub mod serve;
 pub mod serve_config;
+mod serve_lifecycle;
 pub mod util;
 mod verify;
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -598,43 +598,6 @@ async fn spawn_grpc(
     Ok(handle)
 }
 
-async fn await_bg_tasks(tasks: &mut [JoinHandle<()>], timeout_secs: u64) {
-    let timeout = Duration::from_secs(timeout_secs);
-    if tokio::time::timeout(timeout, async {
-        for handle in tasks.iter_mut() {
-            let _ = handle.await;
-        }
-    })
-    .await
-    .is_err()
-    {
-        tracing::warn!("background tasks did not finish within timeout, aborting");
-        for handle in tasks.iter() {
-            handle.abort();
-        }
-    }
-}
-
-async fn drain_connections(connections: &mut JoinSet<()>, timeout_secs: u64) {
-    tracing::info!(
-        "draining {} in-flight connection(s) (timeout {}s)",
-        connections.len(),
-        timeout_secs
-    );
-    let timeout = Duration::from_secs(timeout_secs);
-    if tokio::time::timeout(timeout, async {
-        while connections.join_next().await.is_some() {}
-    })
-    .await
-    .is_err()
-    {
-        tracing::warn!(
-            "shutdown timeout reached, dropping {} connection(s)",
-            connections.len()
-        );
-        connections.shutdown().await;
-    }
-}
 
 /// Wrapper that injects peer IP into request extensions before forwarding.
 #[derive(Clone)]
@@ -700,7 +663,35 @@ async fn accept_loop(
     Ok(connections)
 }
 
-#[allow(clippy::too_many_lines)] // startup orchestration: auth bootstrap, bg tasks, server bind, shutdown
+/// Spawn background tasks: rate-limit cleanup, autovacuum, scrub, metrics updater.
+fn spawn_background_tasks(
+    cfg: &super::serve_config::ServeConfig,
+    storage: &Arc<Storage>,
+    rate_limiter: Option<&Arc<super::rate_limit::IpRateLimiter>>,
+    shutdown_rx: &watch::Receiver<bool>,
+) -> Vec<JoinHandle<()>> {
+    let mut tasks = Vec::new();
+
+    if let Some(limiter) = rate_limiter {
+        tasks.push(super::rate_limit::spawn_cleanup(
+            Arc::clone(limiter),
+            shutdown_rx,
+        ));
+    }
+    if cfg.autovacuum_interval > 0 {
+        tasks.push(spawn_autovacuum(
+            storage, cfg.autovacuum_interval, cfg.autovacuum_threshold, shutdown_rx,
+        ));
+    }
+    if cfg.scrub_interval > 0 {
+        tasks.push(spawn_scrub(storage, cfg.scrub_interval, shutdown_rx));
+    }
+    tasks.push(spawn_metrics_updater(storage, shutdown_rx));
+    tasks
+}
+
+use super::serve_lifecycle::{validate_metrics_auth, graceful_shutdown};
+
 pub async fn run(
     data_dir: &Path,
     cfg: super::serve_config::ServeConfig,
@@ -735,30 +726,11 @@ pub async fn run(
     let sigint = tokio::signal::unix::signal(SignalKind::interrupt())?;
     spawn_signal_handler(sigterm, sigint, shutdown_tx);
 
-    let mut bg_tasks: Vec<JoinHandle<()>> = Vec::new();
-
-    if let Some(ref limiter) = rate_limiter {
-        bg_tasks.push(super::rate_limit::spawn_cleanup(
-            Arc::clone(limiter),
-            &shutdown_rx,
-        ));
-    }
-
-    if cfg.autovacuum_interval > 0 {
-        bg_tasks.push(spawn_autovacuum(
-            &storage, cfg.autovacuum_interval, cfg.autovacuum_threshold, &shutdown_rx,
-        ));
-    }
-
-    if cfg.scrub_interval > 0 {
-        bg_tasks.push(spawn_scrub(&storage, cfg.scrub_interval, &shutdown_rx));
-    }
+    let mut bg_tasks = spawn_background_tasks(&cfg, &storage, rate_limiter.as_ref(), &shutdown_rx);
 
     let prometheus_handle = metrics_exporter_prometheus::PrometheusBuilder::new()
         .install_recorder()
         .map_err(|e| anyhow::anyhow!("prometheus recorder: {e}"))?;
-
-    bg_tasks.push(spawn_metrics_updater(&storage, &shutdown_rx));
 
     let auth_provider = AuthProvider::new(Arc::clone(&auth_store));
     let mut builder = S3ServiceBuilder::new(s3);
@@ -766,21 +738,7 @@ pub async fn run(
     builder.set_access(auth_provider);
     let s3_service = builder.build();
 
-    let metrics_auth = match (cfg.metrics_user, cfg.metrics_password) {
-        (Some(u), Some(p)) if !u.is_empty() && !p.is_empty() => {
-            tracing::info!("metrics endpoint auth enabled");
-            Some(Arc::new((u, p)))
-        }
-        (Some(_), Some(_)) => {
-            anyhow::bail!("metrics auth requires non-empty --metrics-user and --metrics-password");
-        }
-        (Some(_), None) | (None, Some(_)) => {
-            anyhow::bail!(
-                "metrics auth partially configured: both --metrics-user and --metrics-password must be set"
-            );
-        }
-        _ => None,
-    };
+    let metrics_auth = validate_metrics_auth(cfg.metrics_user, cfg.metrics_password)?;
 
     let service = AdminService {
         s3: s3_service,
@@ -812,25 +770,7 @@ pub async fn run(
 
     let mut connections = accept_loop(listener, service, &shutdown_rx).await?;
 
-    tokio::join!(
-        drain_connections(&mut connections, cfg.shutdown_timeout),
-        await_bg_tasks(&mut bg_tasks, cfg.shutdown_timeout),
-    );
-
-    match tokio::task::spawn_blocking(move || storage.sync_all()).await {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => {
-            tracing::error!("failed to sync storage on shutdown: {e}");
-            return Err(e.into());
-        }
-        Err(e) => {
-            tracing::error!("sync_all task panicked: {e}");
-            return Err(e.into());
-        }
-    }
-
-    tracing::info!("shutdown complete");
-    Ok(())
+    graceful_shutdown(&mut connections, &mut bg_tasks, storage, cfg.shutdown_timeout).await
 }
 
 #[cfg(test)]

--- a/src/cli/serve_lifecycle.rs
+++ b/src/cli/serve_lifecycle.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::task::{JoinHandle, JoinSet};
+
+use simple3::storage::Storage;
+
+pub(super) async fn await_bg_tasks(tasks: &mut [JoinHandle<()>], timeout_secs: u64) {
+    let timeout = Duration::from_secs(timeout_secs);
+    if tokio::time::timeout(timeout, async {
+        for handle in tasks.iter_mut() {
+            let _ = handle.await;
+        }
+    })
+    .await
+    .is_err()
+    {
+        tracing::warn!("background tasks did not finish within timeout, aborting");
+        for handle in tasks.iter() {
+            handle.abort();
+        }
+    }
+}
+
+pub(super) async fn drain_connections(connections: &mut JoinSet<()>, timeout_secs: u64) {
+    tracing::info!(
+        "draining {} in-flight connection(s) (timeout {}s)",
+        connections.len(),
+        timeout_secs
+    );
+    let timeout = Duration::from_secs(timeout_secs);
+    if tokio::time::timeout(timeout, async {
+        while connections.join_next().await.is_some() {}
+    })
+    .await
+    .is_err()
+    {
+        tracing::warn!(
+            "shutdown timeout reached, dropping {} connection(s)",
+            connections.len()
+        );
+        connections.shutdown().await;
+    }
+}
+
+/// Validate metrics auth configuration; returns credential pair if enabled.
+pub(super) fn validate_metrics_auth(
+    user: Option<String>,
+    password: Option<String>,
+) -> anyhow::Result<Option<Arc<(String, String)>>> {
+    match (user, password) {
+        (Some(u), Some(p)) if !u.is_empty() && !p.is_empty() => {
+            tracing::info!("metrics endpoint auth enabled");
+            Ok(Some(Arc::new((u, p))))
+        }
+        (Some(_), Some(_)) => {
+            anyhow::bail!("metrics auth requires non-empty --metrics-user and --metrics-password");
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            anyhow::bail!(
+                "metrics auth partially configured: both --metrics-user and --metrics-password must be set"
+            );
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Gracefully drain connections and background tasks, then sync storage.
+pub(super) async fn graceful_shutdown(
+    connections: &mut JoinSet<()>,
+    bg_tasks: &mut [JoinHandle<()>],
+    storage: Arc<Storage>,
+    timeout_secs: u64,
+) -> anyhow::Result<()> {
+    tokio::join!(
+        drain_connections(connections, timeout_secs),
+        await_bg_tasks(bg_tasks, timeout_secs),
+    );
+
+    match tokio::task::spawn_blocking(move || storage.sync_all()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::error!("failed to sync storage on shutdown: {e}");
+            return Err(e.into());
+        }
+        Err(e) => {
+            tracing::error!("sync_all task panicked: {e}");
+            return Err(e.into());
+        }
+    }
+    tracing::info!("shutdown complete");
+    Ok(())
+}

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -13,7 +13,9 @@ use crate::auth::AuthStore;
 use crate::limits::Limits;
 use crate::metrics_util::DurationRecorder;
 use crate::grpc_helpers::{
-    bulk_get_header, bulk_get_not_found, bulk_put_one_object, map_io_err, meta_to_proto,
+    build_list_objects_response, build_list_versions_response, build_verify_response,
+    bulk_get_header, bulk_get_not_found, bulk_put_one_object, clamp_max_keys,
+    execute_batch_delete, execute_copy_blocking, CopyParams, map_io_err, meta_to_proto, non_empty,
     segments_to_proto, spawn_download_stream, stream_to_tmp, TMP_COUNTER,
 };
 use crate::storage::versioning::VersioningState;
@@ -327,45 +329,7 @@ impl Simple3 for GrpcService {
 
         let items = input.items;
         let (deleted, errors) = tokio::task::spawn_blocking(move || {
-            let mut deleted = Vec::new();
-            let mut errors = Vec::new();
-            for item in items {
-                let result = if let Some(vid) = &item.version_id {
-                    let s = Arc::clone(&store);
-                    let k = item.key.clone();
-                    let v = vid.clone();
-                    // Try current version first, then versions table
-                    (|| -> io::Result<Option<crate::types::ObjectMeta>> {
-                        if let Some(m) = s.delete_current_version(&k, &v)? {
-                            return Ok(Some(m));
-                        }
-                        s.delete_version(&k, &v)
-                    })()
-                } else {
-                    store.delete_object(&item.key)
-                };
-
-                match result {
-                    Ok(meta) => {
-                        let (vid, dm) = meta
-                            .as_ref()
-                            .map_or((None, None), |m| {
-                                (m.version_id.clone(), Some(m.is_delete_marker))
-                            });
-                        deleted.push(DeletedObjectResult {
-                            key: item.key,
-                            version_id: vid,
-                            delete_marker: dm,
-                        });
-                    }
-                    Err(e) => errors.push(DeleteError {
-                        key: item.key,
-                        message: e.to_string(),
-                        version_id: item.version_id,
-                    }),
-                }
-            }
-            (deleted, errors)
+            execute_batch_delete(&store, items)
         })
         .await
         .map_err(|e| Status::internal(format!("task panicked: {e}")))?;
@@ -388,54 +352,23 @@ impl Simple3 for GrpcService {
         let src_store = self.bucket(&input.source_bucket)?;
         let dest_store = self.bucket(&input.dest_bucket)?;
 
-        let replace_metadata = input.metadata_directive == "REPLACE";
-        let req_content_type = input.content_type.filter(|s| !s.is_empty());
-        let req_metadata = input.metadata;
-
         let tmp_id = TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let tmp_path = dest_store.bucket_dir().join(format!(".tmp_grpc_{tmp_id:020}"));
-
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or(Duration::ZERO)
-            .as_secs();
-
-        let src_key = input.source_key;
-        let src_vid = input.source_version_id;
-        let ss = Arc::clone(&src_store);
-        let dest_key = input.dest_key;
-        let max_obj_size = self.limits.max_object_size;
+        let params = CopyParams {
+            src_key: input.source_key,
+            src_version_id: input.source_version_id,
+            dest_key: input.dest_key,
+            tmp_path: dest_store.bucket_dir().join(format!(".tmp_grpc_{tmp_id:020}")),
+            replace_metadata: input.metadata_directive == "REPLACE",
+            req_content_type: input.content_type.filter(|s| !s.is_empty()),
+            req_metadata: input.metadata,
+            max_obj_size: self.limits.max_object_size,
+            now: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or(Duration::ZERO)
+                .as_secs(),
+        };
         let (etag, meta, src_version_id_out, size) = tokio::task::spawn_blocking(move || {
-            let src_meta = ss
-                .get_object_or_version(&src_key, src_vid.as_deref())?
-                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "source object not found"))?;
-            if src_meta.is_delete_marker {
-                return Err(io::Error::new(io::ErrorKind::NotFound, "source is a delete marker"));
-            }
-            if max_obj_size > 0 && src_meta.data_length() > max_obj_size {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "EntityTooLarge: source object exceeds max_object_size",
-                ));
-            }
-
-            let (content_type, user_metadata) = if replace_metadata {
-                (req_content_type, req_metadata)
-            } else {
-                (src_meta.content_type.clone(), src_meta.user_metadata.clone())
-            };
-
-            let (etag, crc) = ss.copy_to_tmp_file(&src_meta, &tmp_path)?;
-            let data_len = src_meta.data_length();
-            match dest_store.put_object_streamed(
-                &dest_key, &tmp_path, content_type, etag.clone(), now, user_metadata, Some(crc),
-            ) {
-                Ok(m) => Ok((etag, m, src_meta.version_id, data_len)),
-                Err(e) => {
-                    std::fs::remove_file(&tmp_path).ok();
-                    Err(e)
-                }
-            }
+            execute_copy_blocking(&src_store, &dest_store, params)
         })
         .await
         .map_err(|e| Status::internal(format!("task panicked: {e}")))?
@@ -445,7 +378,7 @@ impl Simple3 for GrpcService {
             etag,
             content_md5: meta.content_md5.unwrap_or_default(),
             size,
-            last_modified: now,
+            last_modified: meta.last_modified,
             source_version_id: src_version_id_out,
             version_id: meta.version_id,
         }))
@@ -461,28 +394,10 @@ impl Simple3 for GrpcService {
         let input = request.into_inner();
         let store = self.bucket(&input.bucket)?;
 
-        let prefix = if input.prefix.is_empty() {
-            None
-        } else {
-            Some(input.prefix)
-        };
-        let delimiter = if input.delimiter.is_empty() {
-            None
-        } else {
-            Some(input.delimiter)
-        };
-        #[allow(clippy::cast_sign_loss)]
-        let max_keys = (if input.max_keys <= 0 {
-            1000
-        } else {
-            input.max_keys as usize
-        })
-        .min(self.limits.max_list_keys);
-        let continuation = if input.continuation_token.is_empty() {
-            None
-        } else {
-            Some(input.continuation_token)
-        };
+        let prefix = non_empty(input.prefix);
+        let delimiter = non_empty(input.delimiter);
+        let max_keys = clamp_max_keys(input.max_keys, self.limits.max_list_keys);
+        let continuation = non_empty(input.continuation_token);
 
         let (entries, common_prefixes, truncated) = tokio::task::spawn_blocking(move || {
             store.list_objects_with_delimiter(
@@ -496,29 +411,11 @@ impl Simple3 for GrpcService {
         .map_err(|e| Status::internal(format!("task panicked: {e}")))?
         .map_err(map_io_err)?;
 
-        let next_token = if truncated {
-            entries.last().map(|(k, _)| k.clone()).unwrap_or_default()
-        } else {
-            String::new()
-        };
-
-        let objects: Vec<ObjectInfo> = entries
-            .into_iter()
-            .map(|(key, meta)| ObjectInfo {
-                key,
-                size: meta.data_length(),
-                etag: meta.etag,
-                last_modified: meta.last_modified,
-                version_id: meta.version_id,
-            })
-            .collect();
-
-        Ok(Response::new(ListObjectsResponse {
-            objects,
+        Ok(Response::new(build_list_objects_response(
+            entries,
             common_prefixes,
-            is_truncated: truncated,
-            next_continuation_token: next_token,
-        }))
+            truncated,
+        )))
     }
 
     // ================================================================
@@ -803,33 +700,11 @@ impl Simple3 for GrpcService {
         let input = request.into_inner();
         let store = self.bucket(&input.bucket)?;
 
-        let prefix = if input.prefix.is_empty() {
-            None
-        } else {
-            Some(input.prefix)
-        };
-        let delimiter = if input.delimiter.is_empty() {
-            None
-        } else {
-            Some(input.delimiter)
-        };
-        #[allow(clippy::cast_sign_loss)]
-        let max_keys = (if input.max_keys <= 0 {
-            1000
-        } else {
-            input.max_keys as usize
-        })
-        .min(self.limits.max_list_keys);
-        let key_marker = if input.key_marker.is_empty() {
-            None
-        } else {
-            Some(input.key_marker)
-        };
-        let vid_marker = if input.version_id_marker.is_empty() {
-            None
-        } else {
-            Some(input.version_id_marker)
-        };
+        let prefix = non_empty(input.prefix);
+        let delimiter = non_empty(input.delimiter);
+        let max_keys = clamp_max_keys(input.max_keys, self.limits.max_list_keys);
+        let key_marker = non_empty(input.key_marker);
+        let vid_marker = non_empty(input.version_id_marker);
 
         let result = tokio::task::spawn_blocking(move || {
             store.list_object_versions(
@@ -844,45 +719,8 @@ impl Simple3 for GrpcService {
         .map_err(|e| Status::internal(format!("task panicked: {e}")))?
         .map_err(map_io_err)?;
 
-        let mut versions = Vec::new();
-        let mut delete_markers = Vec::new();
-
-        for entry in result.entries {
-            if entry.meta.is_delete_marker {
-                delete_markers.push(DeleteMarkerProto {
-                    key: entry.key,
-                    version_id: entry.version_id,
-                    last_modified: entry.meta.last_modified,
-                    is_latest: entry.is_latest,
-                });
-            } else {
-                let size = entry.meta.data_length();
-                let last_modified = entry.meta.last_modified;
-                versions.push(proto::VersionEntry {
-                    key: entry.key,
-                    version_id: entry.version_id,
-                    etag: entry.meta.etag,
-                    size,
-                    last_modified,
-                    is_latest: entry.is_latest,
-                    content_type: entry.meta.content_type.unwrap_or_default(),
-                });
-            }
-        }
-
-        Ok(Response::new(ListObjectVersionsResponse {
-            versions,
-            delete_markers,
-            common_prefixes: result.common_prefixes,
-            is_truncated: result.is_truncated,
-            next_key_marker: result.next_key_marker.unwrap_or_default(),
-            next_version_id_marker: result.next_version_id_marker.unwrap_or_default(),
-        }))
+        Ok(Response::new(build_list_versions_response(result)))
     }
-
-    // ================================================================
-    // Admin
-    // ================================================================
 
     async fn stats(
         &self,
@@ -895,28 +733,14 @@ impl Simple3 for GrpcService {
         let store = self.bucket(&bucket)?;
 
         let s = Arc::clone(&store);
-        let (stats, vstats) = tokio::task::spawn_blocking(move || {
-            let seg = s.segment_stats()?;
-            let ver = s.version_stats()?;
-            Ok::<_, io::Error>((seg, ver))
+        let resp = tokio::task::spawn_blocking(move || {
+            crate::grpc_helpers::build_stats_response(bucket, &s)
         })
         .await
         .map_err(|e| Status::internal(format!("task panicked: {e}")))?
         .map_err(map_io_err)?;
 
-        let total_size: u64 = stats.iter().map(|s| s.size).sum();
-        let total_dead_bytes: u64 = stats.iter().map(|s| s.dead_bytes).sum();
-        let (version_count, delete_marker_count, total_versioned_size) = vstats;
-
-        Ok(Response::new(StatsResponse {
-            bucket,
-            segments: segments_to_proto(stats),
-            total_size,
-            total_dead_bytes,
-            version_count,
-            delete_marker_count,
-            total_versioned_size,
-        }))
+        Ok(Response::new(resp))
     }
 
     async fn compact(
@@ -969,23 +793,6 @@ impl Simple3 for GrpcService {
             .map_err(|e| Status::internal(format!("task panicked: {e}")))?
             .map_err(map_io_err)?;
 
-        let errors = result
-            .errors
-            .into_iter()
-            .map(|e| proto::VerifyError {
-                key: e.key,
-                kind: format!("{:?}", e.kind),
-                detail: e.detail,
-            })
-            .collect();
-
-        Ok(Response::new(VerifyResponse {
-            total_objects: result.total_objects,
-            verified_ok: result.verified_ok,
-            checksum_errors: result.checksum_errors,
-            read_errors: result.read_errors,
-            errors,
-            crc_errors: result.crc_errors,
-        }))
+        Ok(Response::new(build_verify_response(result)))
     }
 }

--- a/src/grpc_helpers.rs
+++ b/src/grpc_helpers.rs
@@ -305,7 +305,7 @@ pub(crate) fn non_empty(s: String) -> Option<String> {
 
 /// Clamp a signed `max_keys` value from the client to a positive `usize`
 /// bounded by the server-configured limit.
-#[allow(clippy::cast_sign_loss)]
+#[allow(clippy::cast_sign_loss)] // negative values already handled by the <= 0 branch above
 pub(crate) fn clamp_max_keys(raw: i32, server_limit: usize) -> usize {
     (if raw <= 0 { 1000 } else { raw as usize }).min(server_limit)
 }

--- a/src/grpc_helpers.rs
+++ b/src/grpc_helpers.rs
@@ -8,10 +8,13 @@ use tokio::sync::mpsc;
 use tonic::{Status, Streaming};
 
 use crate::grpc::proto::{
-    self, BulkGetObjectStart, BulkGetResponse, BulkPutRequest, GetObjectResponse,
-    ObjectMetadata, PutObjectInit, PutObjectRequest,
+    self, BulkGetObjectStart, BulkGetResponse, BulkPutRequest, DeleteError,
+    DeleteMarkerProto, DeleteObjectIdentifier, DeletedObjectResult, GetObjectResponse,
+    ListObjectVersionsResponse, ListObjectsResponse, ObjectInfo, ObjectMetadata, PutObjectInit,
+    PutObjectRequest, StatsResponse, VerifyResponse,
 };
-use crate::storage::{BucketStore, SegmentStat};
+use crate::storage::versioning::ListVersionsResult;
+use crate::storage::{BucketStore, SegmentStat, VerifyResult};
 use crate::types::ObjectMeta;
 
 /// Monotonic counter for unique temp file names.
@@ -289,4 +292,233 @@ pub fn bulk_get_header(key: &str, meta: &ObjectMeta) -> BulkGetResponse {
             },
         )),
     }
+}
+
+// ================================================================
+// Helpers extracted from grpc.rs
+// ================================================================
+
+/// Convert an empty string to `None`.
+pub(crate) fn non_empty(s: String) -> Option<String> {
+    if s.is_empty() { None } else { Some(s) }
+}
+
+/// Clamp a signed `max_keys` value from the client to a positive `usize`
+/// bounded by the server-configured limit.
+#[allow(clippy::cast_sign_loss)]
+pub(crate) fn clamp_max_keys(raw: i32, server_limit: usize) -> usize {
+    (if raw <= 0 { 1000 } else { raw as usize }).min(server_limit)
+}
+
+/// Build a `ListObjectsResponse` from storage results.
+pub(crate) fn build_list_objects_response(
+    entries: Vec<(String, ObjectMeta)>,
+    common_prefixes: Vec<String>,
+    truncated: bool,
+) -> ListObjectsResponse {
+    let next_token = if truncated {
+        entries.last().map(|(k, _)| k.clone()).unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    let objects: Vec<ObjectInfo> = entries
+        .into_iter()
+        .map(|(key, meta)| ObjectInfo {
+            key,
+            size: meta.data_length(),
+            etag: meta.etag,
+            last_modified: meta.last_modified,
+            version_id: meta.version_id,
+        })
+        .collect();
+
+    ListObjectsResponse {
+        objects,
+        common_prefixes,
+        is_truncated: truncated,
+        next_continuation_token: next_token,
+    }
+}
+
+/// Build a `ListObjectVersionsResponse` from storage results.
+pub(crate) fn build_list_versions_response(
+    result: ListVersionsResult,
+) -> ListObjectVersionsResponse {
+    let mut versions = Vec::new();
+    let mut delete_markers = Vec::new();
+
+    for entry in result.entries {
+        if entry.meta.is_delete_marker {
+            delete_markers.push(DeleteMarkerProto {
+                key: entry.key,
+                version_id: entry.version_id,
+                last_modified: entry.meta.last_modified,
+                is_latest: entry.is_latest,
+            });
+        } else {
+            let size = entry.meta.data_length();
+            let last_modified = entry.meta.last_modified;
+            versions.push(proto::VersionEntry {
+                key: entry.key,
+                version_id: entry.version_id,
+                etag: entry.meta.etag,
+                size,
+                last_modified,
+                is_latest: entry.is_latest,
+                content_type: entry.meta.content_type.unwrap_or_default(),
+            });
+        }
+    }
+
+    ListObjectVersionsResponse {
+        versions,
+        delete_markers,
+        common_prefixes: result.common_prefixes,
+        is_truncated: result.is_truncated,
+        next_key_marker: result.next_key_marker.unwrap_or_default(),
+        next_version_id_marker: result.next_version_id_marker.unwrap_or_default(),
+    }
+}
+
+/// Execute batch delete on a list of items, returning deleted and error lists.
+pub(crate) fn execute_batch_delete(
+    store: &Arc<BucketStore>,
+    items: Vec<DeleteObjectIdentifier>,
+) -> (Vec<DeletedObjectResult>, Vec<DeleteError>) {
+    let mut deleted = Vec::new();
+    let mut errors = Vec::new();
+    for item in items {
+        let result = if let Some(vid) = &item.version_id {
+            let s = Arc::clone(store);
+            let k = item.key.clone();
+            let v: String = vid.clone();
+            (|| -> io::Result<Option<ObjectMeta>> {
+                if let Some(m) = s.delete_current_version(&k, &v)? {
+                    return Ok(Some(m));
+                }
+                s.delete_version(&k, &v)
+            })()
+        } else {
+            store.delete_object(&item.key)
+        };
+
+        match result {
+            Ok(meta) => {
+                let (vid, dm) = meta.as_ref().map_or((None, None), |m| {
+                    (m.version_id.clone(), Some(m.is_delete_marker))
+                });
+                deleted.push(DeletedObjectResult {
+                    key: item.key,
+                    version_id: vid,
+                    delete_marker: dm,
+                });
+            }
+            Err(e) => errors.push(DeleteError {
+                key: item.key,
+                message: e.to_string(),
+                version_id: item.version_id,
+            }),
+        }
+    }
+    (deleted, errors)
+}
+
+/// Build a `VerifyResponse` from a storage `VerifyResult`.
+pub(crate) fn build_verify_response(result: VerifyResult) -> VerifyResponse {
+    let errors = result
+        .errors
+        .into_iter()
+        .map(|e| proto::VerifyError {
+            key: e.key,
+            kind: format!("{:?}", e.kind),
+            detail: e.detail,
+        })
+        .collect();
+
+    VerifyResponse {
+        total_objects: result.total_objects,
+        verified_ok: result.verified_ok,
+        checksum_errors: result.checksum_errors,
+        read_errors: result.read_errors,
+        errors,
+        crc_errors: result.crc_errors,
+    }
+}
+
+/// Parameters for `execute_copy_blocking`.
+pub(crate) struct CopyParams {
+    pub src_key: String,
+    pub src_version_id: Option<String>,
+    pub dest_key: String,
+    pub tmp_path: std::path::PathBuf,
+    pub replace_metadata: bool,
+    pub req_content_type: Option<String>,
+    pub req_metadata: std::collections::HashMap<String, String>,
+    pub max_obj_size: u64,
+    pub now: u64,
+}
+
+/// Execute the blocking copy-object logic: read source, write to tmp, put in dest.
+///
+/// Returns `(etag, dest_meta, source_version_id, data_length)`.
+pub(crate) fn execute_copy_blocking(
+    src_store: &Arc<BucketStore>,
+    dest_store: &Arc<BucketStore>,
+    p: CopyParams,
+) -> io::Result<(String, ObjectMeta, Option<String>, u64)> {
+    let src_meta = src_store
+        .get_object_or_version(&p.src_key, p.src_version_id.as_deref())?
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "source object not found"))?;
+    if src_meta.is_delete_marker {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "source is a delete marker",
+        ));
+    }
+    if p.max_obj_size > 0 && src_meta.data_length() > p.max_obj_size {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "EntityTooLarge: source object exceeds max_object_size",
+        ));
+    }
+
+    let (content_type, user_metadata) = if p.replace_metadata {
+        (p.req_content_type, p.req_metadata)
+    } else {
+        (src_meta.content_type.clone(), src_meta.user_metadata.clone())
+    };
+
+    let (etag, crc) = src_store.copy_to_tmp_file(&src_meta, &p.tmp_path)?;
+    let data_len = src_meta.data_length();
+    match dest_store.put_object_streamed(
+        &p.dest_key, &p.tmp_path, content_type, etag.clone(), p.now, user_metadata, Some(crc),
+    ) {
+        Ok(m) => Ok((etag, m, src_meta.version_id, data_len)),
+        Err(e) => {
+            std::fs::remove_file(&p.tmp_path).ok();
+            Err(e)
+        }
+    }
+}
+
+/// Gather segment and version stats and build a `StatsResponse`.
+pub(crate) fn build_stats_response(
+    bucket: String,
+    store: &BucketStore,
+) -> io::Result<StatsResponse> {
+    let stats = store.segment_stats()?;
+    let (version_count, delete_marker_count, total_versioned_size) = store.version_stats()?;
+    let total_size: u64 = stats.iter().map(|s| s.size).sum();
+    let total_dead_bytes: u64 = stats.iter().map(|s| s.dead_bytes).sum();
+
+    Ok(StatsResponse {
+        bucket,
+        segments: segments_to_proto(stats),
+        total_size,
+        total_dead_bytes,
+        version_count,
+        delete_marker_count,
+        total_versioned_size,
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,6 @@ pub mod grpc_helpers;
 pub mod limits;
 pub mod metrics_util;
 pub mod s3impl;
+pub mod s3impl_helpers;
 pub mod storage;
 pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,6 @@ pub mod grpc_helpers;
 pub mod limits;
 pub mod metrics_util;
 pub mod s3impl;
-pub mod s3impl_helpers;
+mod s3impl_helpers;
 pub mod storage;
 pub mod types;

--- a/src/s3impl.rs
+++ b/src/s3impl.rs
@@ -1,24 +1,19 @@
 use std::collections::HashMap;
 use std::io;
-use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use futures::TryStreamExt;
-use md5::{Digest, Md5};
 use s3s::dto::{
     AbortMultipartUploadInput, AbortMultipartUploadOutput, Bucket, BucketVersioningStatus,
-    CommonPrefix, CompleteMultipartUploadInput, CompleteMultipartUploadOutput,
-    CopyObjectInput, CopyObjectOutput, CopyObjectResult, CopySource, CreateBucketInput,
-    CreateBucketOutput, CreateMultipartUploadInput, CreateMultipartUploadOutput,
-    DeleteBucketInput, DeleteBucketOutput, DeleteMarkerEntry, DeleteObjectInput,
-    DeleteObjectOutput, DeleteObjectsInput, DeleteObjectsOutput, DeletedObject, ETag,
-    GetBucketVersioningInput, GetBucketVersioningOutput, GetObjectInput, GetObjectOutput,
-    HeadBucketInput, HeadBucketOutput, HeadObjectInput, HeadObjectOutput,
-    ListBucketsInput, ListBucketsOutput,
-    ListObjectVersionsInput, ListObjectVersionsOutput, ListObjectsV2Input, ListObjectsV2Output,
-    MetadataDirective, Object, ObjectVersion, PutBucketVersioningInput,
+    CommonPrefix, CompleteMultipartUploadInput, CompleteMultipartUploadOutput, CopyObjectInput,
+    CopyObjectOutput, CopyObjectResult, CopySource, CreateBucketInput, CreateBucketOutput,
+    CreateMultipartUploadInput, CreateMultipartUploadOutput, DeleteBucketInput, DeleteBucketOutput,
+    DeleteObjectInput, DeleteObjectOutput, DeleteObjectsInput, DeleteObjectsOutput, DeletedObject,
+    ETag, GetBucketVersioningInput, GetBucketVersioningOutput, GetObjectInput, GetObjectOutput,
+    HeadBucketInput, HeadBucketOutput, HeadObjectInput, HeadObjectOutput, ListBucketsInput,
+    ListBucketsOutput, ListObjectVersionsInput, ListObjectVersionsOutput, ListObjectsV2Input,
+    ListObjectsV2Output, MetadataDirective, Object, PutBucketVersioningInput,
     PutBucketVersioningOutput, PutObjectInput, PutObjectOutput, StreamingBlob, Timestamp,
     UploadPartInput, UploadPartOutput,
 };
@@ -26,23 +21,12 @@ use s3s::{s3_error, S3Request, S3Response, S3Result, S3};
 
 use crate::limits::Limits;
 use crate::metrics_util::DurationRecorder;
+use crate::s3impl_helpers::{
+    TMP_COUNTER, blocking, build_version_lists, delete_one_unversioned, delete_one_versioned,
+    execute_copy_blocking, resolve_object_version, stream_body_to_tmp, version_id_string,
+};
 use crate::storage::versioning::VersioningState;
 use crate::storage::{BucketStore, Storage};
-use crate::types::ObjectMeta;
-
-/// Monotonic counter for unique temp file names across concurrent requests.
-static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Run a blocking closure on the tokio blocking thread pool.
-async fn blocking<F, T>(f: F) -> Result<T, io::Error>
-where
-    F: FnOnce() -> io::Result<T> + Send + 'static,
-    T: Send + 'static,
-{
-    tokio::task::spawn_blocking(f)
-        .await
-        .map_err(|e| io::Error::other(format!("task panicked: {e}")))?
-}
 
 pub struct SimpleStorage {
     inner: Arc<Storage>,
@@ -60,60 +44,6 @@ impl SimpleStorage {
             .map_err(|e| { tracing::error!("get_bucket({name}): {e}"); s3_error!(e, InternalError) })?
             .ok_or_else(|| s3_error!(NoSuchBucket))
     }
-}
-
-/// Stream request body to a temp file, returning `(md5_hex, crc32c)`.
-/// When `max_size > 0`, aborts with `EntityTooLarge` if the body exceeds the limit.
-async fn stream_body_to_tmp(body: StreamingBlob, tmp_path: &Path, max_size: u64) -> S3Result<(String, u32)> {
-    let file = tokio::fs::File::create(tmp_path).await
-        .map_err(|e| { tracing::error!("create tmp file: {e}"); s3_error!(e, InternalError) })?;
-    let mut writer = tokio::io::BufWriter::with_capacity(1024 * 1024, file);
-    let mut hasher = Md5::new();
-    let mut crc: u32 = 0;
-    let mut total_bytes = 0u64;
-    let mut stream = body;
-
-    while let Some(chunk) = stream.try_next().await.map_err(|e| { tracing::error!("read request body: {e}"); s3_error!(InternalError) })? {
-        total_bytes += chunk.len() as u64;
-        if max_size > 0 && total_bytes > max_size {
-            drop(writer);
-            tokio::fs::remove_file(tmp_path).await.ok();
-            return Err(s3_error!(EntityTooLarge));
-        }
-        tokio::io::AsyncWriteExt::write_all(&mut writer, &chunk).await
-            .map_err(|e| { tracing::error!("write tmp file: {e}"); s3_error!(e, InternalError) })?;
-        hasher.update(&chunk);
-        crc = crc32c::crc32c_append(crc, &chunk);
-    }
-    tokio::io::AsyncWriteExt::flush(&mut writer).await
-        .map_err(|e| { tracing::error!("flush tmp file: {e}"); s3_error!(e, InternalError) })?;
-
-    metrics::counter!("simple3_bytes_received_total").increment(total_bytes);
-    Ok((format!("{:x}", hasher.finalize()), crc))
-}
-
-fn version_id_string(vid: Option<&str>) -> Option<String> {
-    vid.map(str::to_owned)
-}
-
-/// Resolve an object by key, optionally looking up a specific version.
-/// Uses a single read transaction to avoid TOCTOU between tables.
-/// Returns the meta or an `io::Error` with appropriate `ErrorKind`.
-fn resolve_object_version(
-    store: &BucketStore,
-    key: &str,
-    version_id: Option<&str>,
-) -> io::Result<ObjectMeta> {
-    let not_found_msg = if version_id.is_some() { "NoSuchVersion" } else { "NoSuchKey" };
-    let meta = store
-        .get_object_or_version(key, version_id)?
-        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, not_found_msg))?;
-
-    if meta.is_delete_marker {
-        return Err(io::Error::new(io::ErrorKind::NotFound, "DeleteMarker"));
-    }
-
-    Ok(meta)
 }
 
 #[async_trait::async_trait]
@@ -197,8 +127,6 @@ impl S3 for SimpleStorage {
         Ok(S3Response::new(output))
     }
 
-    // === Bucket versioning ===
-
     async fn put_bucket_versioning(
         &self,
         req: S3Request<PutBucketVersioningInput>,
@@ -263,8 +191,6 @@ impl S3 for SimpleStorage {
         };
         Ok(S3Response::new(output))
     }
-
-    // === Object operations ===
 
     async fn put_object(
         &self,
@@ -479,32 +405,11 @@ impl S3 for SimpleStorage {
         let dest_key = input.key;
         let max_obj_size = self.limits.max_object_size;
         let result = blocking(move || {
-            let src_meta = resolve_object_version(&ss, &src_key, src_vid.as_deref())?;
-
-            if max_obj_size > 0 && src_meta.data_length() > max_obj_size {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "EntityTooLarge: source object exceeds max_object_size",
-                ));
-            }
-
-            let (content_type, user_metadata) = if replace_metadata {
-                (req_content_type, req_metadata)
-            } else {
-                (src_meta.content_type.clone(), src_meta.user_metadata.clone())
-            };
-
-            let (etag_hex, crc) = ss.copy_to_tmp_file(&src_meta, &tmp_path)?;
-            let data_len = src_meta.data_length();
-            match dest_store.put_object_streamed(
-                &dest_key, &tmp_path, content_type, etag_hex.clone(), now, user_metadata, Some(crc),
-            ) {
-                Ok(m) => Ok((etag_hex, m, src_meta.version_id, data_len)),
-                Err(e) => {
-                    std::fs::remove_file(&tmp_path).ok();
-                    Err(e)
-                }
-            }
+            execute_copy_blocking(
+                &ss, &dest_store, &src_key, src_vid.as_deref(), &dest_key,
+                &tmp_path, replace_metadata, req_content_type, req_metadata,
+                now, max_obj_size,
+            )
         })
         .await
         .map_err(|e| {
@@ -574,7 +479,6 @@ impl S3 for SimpleStorage {
         Ok(S3Response::new(output))
     }
 
-    #[allow(clippy::too_many_lines)] // per-item version/non-version branching in batch delete
     async fn delete_objects(
         &self,
         req: S3Request<DeleteObjectsInput>,
@@ -591,76 +495,14 @@ impl S3 for SimpleStorage {
 
             for obj_id in objects {
                 let key = obj_id.key;
-                let version_id = obj_id.version_id;
-
-                if let Some(vid) = version_id {
-                    // Version-specific delete
-                    match store.delete_current_version(&key, &vid) {
-                        Ok(Some(meta)) => {
-                            deleted_list.push(DeletedObject {
-                                key: Some(key),
-                                version_id: Some(vid),
-                                delete_marker: Some(meta.is_delete_marker),
-                                ..Default::default()
-                            });
-                        }
-                        Ok(None) => {
-                            // Try versions table
-                            match store.delete_version(&key, &vid) {
-                                Ok(Some(meta)) => {
-                                    deleted_list.push(DeletedObject {
-                                        key: Some(key),
-                                        version_id: Some(vid),
-                                        delete_marker: if meta.is_delete_marker { Some(true) } else { None },
-                                        ..Default::default()
-                                    });
-                                }
-                                Ok(None) => {
-                                    deleted_list.push(DeletedObject {
-                                        key: Some(key),
-                                        version_id: Some(vid),
-                                        ..Default::default()
-                                    });
-                                }
-                                Err(e) => errors.push(s3s::dto::Error {
-                                    code: Some("InternalError".to_owned()),
-                                    key: Some(key),
-                                    message: Some(e.to_string()),
-                                    version_id: Some(vid),
-                                }),
-                            }
-                        }
-                        Err(e) => errors.push(s3s::dto::Error {
-                            code: Some("InternalError".to_owned()),
-                            key: Some(key),
-                            message: Some(e.to_string()),
-                            version_id: Some(vid),
-                        }),
-                    }
+                let result = if let Some(vid) = obj_id.version_id {
+                    delete_one_versioned(&store, key, vid)
                 } else {
-                    // No version_id: hard delete or create delete marker
-                    match store.delete_object(&key) {
-                        Ok(Some(meta)) => {
-                            deleted_list.push(DeletedObject {
-                                key: Some(key),
-                                version_id: version_id_string(meta.version_id.as_deref()),
-                                delete_marker: if meta.is_delete_marker { Some(true) } else { None },
-                                ..Default::default()
-                            });
-                        }
-                        Ok(None) => {
-                            deleted_list.push(DeletedObject {
-                                key: Some(key),
-                                ..Default::default()
-                            });
-                        }
-                        Err(e) => errors.push(s3s::dto::Error {
-                            code: Some("InternalError".to_owned()),
-                            key: Some(key),
-                            message: Some(e.to_string()),
-                            version_id: None,
-                        }),
-                    }
+                    delete_one_unversioned(&store, key)
+                };
+                match result {
+                    Ok(deleted) => deleted_list.push(deleted),
+                    Err(err) => errors.push(err),
                 }
             }
             Ok((deleted_list, errors))
@@ -761,9 +603,6 @@ impl S3 for SimpleStorage {
         Ok(S3Response::new(output))
     }
 
-    // === ListObjectVersions ===
-
-    #[allow(clippy::too_many_lines)] // maps storage entries to S3 DTOs with version/delete-marker split
     async fn list_object_versions(
         &self,
         req: S3Request<ListObjectVersionsInput>,
@@ -791,34 +630,7 @@ impl S3 for SimpleStorage {
         .await
         .map_err(|e| { tracing::error!("list_object_versions: {e}"); s3_error!(e, InternalError) })?;
 
-        let mut versions = Vec::new();
-        let mut delete_markers = Vec::new();
-
-        for entry in result.entries {
-            let last_modified =
-                Timestamp::from(UNIX_EPOCH + Duration::from_secs(entry.meta.last_modified));
-
-            if entry.meta.is_delete_marker {
-                delete_markers.push(DeleteMarkerEntry {
-                    is_latest: Some(entry.is_latest),
-                    key: Some(entry.key),
-                    last_modified: Some(last_modified),
-                    version_id: Some(entry.version_id),
-                    ..Default::default()
-                });
-            } else {
-                let size = entry.meta.data_length().cast_signed();
-                versions.push(ObjectVersion {
-                    e_tag: Some(ETag::Strong(entry.meta.etag)),
-                    is_latest: Some(entry.is_latest),
-                    key: Some(entry.key),
-                    last_modified: Some(last_modified),
-                    size: Some(size),
-                    version_id: Some(entry.version_id),
-                    ..Default::default()
-                });
-            }
-        }
+        let (versions, delete_markers) = build_version_lists(result.entries);
 
         let cp: Option<Vec<CommonPrefix>> = if result.common_prefixes.is_empty() {
             None
@@ -849,8 +661,6 @@ impl S3 for SimpleStorage {
         };
         Ok(S3Response::new(output))
     }
-
-    // === Multipart upload ===
 
     async fn create_multipart_upload(
         &self,

--- a/src/s3impl_helpers.rs
+++ b/src/s3impl_helpers.rs
@@ -15,10 +15,10 @@ use crate::storage::BucketStore;
 use crate::types::ObjectMeta;
 
 /// Monotonic counter for unique temp file names across concurrent requests.
-pub(crate) static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+pub static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Run a blocking closure on the tokio blocking thread pool.
-pub(crate) async fn blocking<F, T>(f: F) -> Result<T, io::Error>
+pub async fn blocking<F, T>(f: F) -> Result<T, io::Error>
 where
     F: FnOnce() -> io::Result<T> + Send + 'static,
     T: Send + 'static,
@@ -30,7 +30,7 @@ where
 
 /// Stream request body to a temp file, returning `(md5_hex, crc32c)`.
 /// When `max_size > 0`, aborts with `EntityTooLarge` if the body exceeds the limit.
-pub(crate) async fn stream_body_to_tmp(
+pub async fn stream_body_to_tmp(
     body: StreamingBlob,
     tmp_path: &Path,
     max_size: u64,
@@ -62,12 +62,12 @@ pub(crate) async fn stream_body_to_tmp(
     Ok((format!("{:x}", hasher.finalize()), crc))
 }
 
-pub(crate) fn version_id_string(vid: Option<&str>) -> Option<String> {
+pub fn version_id_string(vid: Option<&str>) -> Option<String> {
     vid.map(str::to_owned)
 }
 
 /// Delete a single object with a specific version ID.
-pub(crate) fn delete_one_versioned(
+pub fn delete_one_versioned(
     store: &BucketStore,
     key: String,
     vid: String,
@@ -108,7 +108,7 @@ pub(crate) fn delete_one_versioned(
 }
 
 /// Delete a single object without a version ID (hard delete or create delete marker).
-pub(crate) fn delete_one_unversioned(
+pub fn delete_one_unversioned(
     store: &BucketStore,
     key: String,
 ) -> Result<DeletedObject, s3s::dto::Error> {
@@ -133,7 +133,7 @@ pub(crate) fn delete_one_unversioned(
 }
 
 /// Build version/delete-marker lists from storage version entries.
-pub(crate) fn build_version_lists(
+pub fn build_version_lists(
     entries: Vec<VersionEntry>,
 ) -> (Vec<ObjectVersion>, Vec<DeleteMarkerEntry>) {
     let mut versions = Vec::new();
@@ -171,7 +171,7 @@ pub(crate) fn build_version_lists(
 /// Resolve an object by key, optionally looking up a specific version.
 /// Uses a single read transaction to avoid TOCTOU between tables.
 /// Returns the meta or an `io::Error` with appropriate `ErrorKind`.
-pub(crate) fn resolve_object_version(
+pub fn resolve_object_version(
     store: &BucketStore,
     key: &str,
     version_id: Option<&str>,
@@ -189,8 +189,8 @@ pub(crate) fn resolve_object_version(
 }
 
 /// Execute copy-object blocking operation: resolve source, copy to tmp, put in destination.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn execute_copy_blocking(
+#[allow(clippy::too_many_arguments)] // all fields required for atomic copy-put; matches existing pattern in grpc_helpers::CopyParams
+pub fn execute_copy_blocking(
     src_store: &BucketStore,
     dest_store: &BucketStore,
     src_key: &str,

--- a/src/s3impl_helpers.rs
+++ b/src/s3impl_helpers.rs
@@ -1,0 +1,233 @@
+use std::io;
+use std::path::Path;
+use std::sync::atomic::AtomicU64;
+use std::time::{Duration, UNIX_EPOCH};
+
+use futures::TryStreamExt;
+use md5::{Digest, Md5};
+use s3s::dto::{
+    DeleteMarkerEntry, DeletedObject, ETag, ObjectVersion, StreamingBlob, Timestamp,
+};
+use s3s::{s3_error, S3Result};
+
+use crate::storage::versioning::VersionEntry;
+use crate::storage::BucketStore;
+use crate::types::ObjectMeta;
+
+/// Monotonic counter for unique temp file names across concurrent requests.
+pub(crate) static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Run a blocking closure on the tokio blocking thread pool.
+pub(crate) async fn blocking<F, T>(f: F) -> Result<T, io::Error>
+where
+    F: FnOnce() -> io::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| io::Error::other(format!("task panicked: {e}")))?
+}
+
+/// Stream request body to a temp file, returning `(md5_hex, crc32c)`.
+/// When `max_size > 0`, aborts with `EntityTooLarge` if the body exceeds the limit.
+pub(crate) async fn stream_body_to_tmp(
+    body: StreamingBlob,
+    tmp_path: &Path,
+    max_size: u64,
+) -> S3Result<(String, u32)> {
+    let file = tokio::fs::File::create(tmp_path).await
+        .map_err(|e| { tracing::error!("create tmp file: {e}"); s3_error!(e, InternalError) })?;
+    let mut writer = tokio::io::BufWriter::with_capacity(1024 * 1024, file);
+    let mut hasher = Md5::new();
+    let mut crc: u32 = 0;
+    let mut total_bytes = 0u64;
+    let mut stream = body;
+
+    while let Some(chunk) = stream.try_next().await.map_err(|e| { tracing::error!("read request body: {e}"); s3_error!(InternalError) })? {
+        total_bytes += chunk.len() as u64;
+        if max_size > 0 && total_bytes > max_size {
+            drop(writer);
+            tokio::fs::remove_file(tmp_path).await.ok();
+            return Err(s3_error!(EntityTooLarge));
+        }
+        tokio::io::AsyncWriteExt::write_all(&mut writer, &chunk).await
+            .map_err(|e| { tracing::error!("write tmp file: {e}"); s3_error!(e, InternalError) })?;
+        hasher.update(&chunk);
+        crc = crc32c::crc32c_append(crc, &chunk);
+    }
+    tokio::io::AsyncWriteExt::flush(&mut writer).await
+        .map_err(|e| { tracing::error!("flush tmp file: {e}"); s3_error!(e, InternalError) })?;
+
+    metrics::counter!("simple3_bytes_received_total").increment(total_bytes);
+    Ok((format!("{:x}", hasher.finalize()), crc))
+}
+
+pub(crate) fn version_id_string(vid: Option<&str>) -> Option<String> {
+    vid.map(str::to_owned)
+}
+
+/// Delete a single object with a specific version ID.
+pub(crate) fn delete_one_versioned(
+    store: &BucketStore,
+    key: String,
+    vid: String,
+) -> Result<DeletedObject, s3s::dto::Error> {
+    match store.delete_current_version(&key, &vid) {
+        Ok(Some(meta)) => Ok(DeletedObject {
+            key: Some(key),
+            version_id: Some(vid),
+            delete_marker: Some(meta.is_delete_marker),
+            ..Default::default()
+        }),
+        Ok(None) => match store.delete_version(&key, &vid) {
+            Ok(Some(meta)) => Ok(DeletedObject {
+                key: Some(key),
+                version_id: Some(vid),
+                delete_marker: if meta.is_delete_marker { Some(true) } else { None },
+                ..Default::default()
+            }),
+            Ok(None) => Ok(DeletedObject {
+                key: Some(key),
+                version_id: Some(vid),
+                ..Default::default()
+            }),
+            Err(e) => Err(s3s::dto::Error {
+                code: Some("InternalError".to_owned()),
+                key: Some(key),
+                message: Some(e.to_string()),
+                version_id: Some(vid),
+            }),
+        },
+        Err(e) => Err(s3s::dto::Error {
+            code: Some("InternalError".to_owned()),
+            key: Some(key),
+            message: Some(e.to_string()),
+            version_id: Some(vid),
+        }),
+    }
+}
+
+/// Delete a single object without a version ID (hard delete or create delete marker).
+pub(crate) fn delete_one_unversioned(
+    store: &BucketStore,
+    key: String,
+) -> Result<DeletedObject, s3s::dto::Error> {
+    match store.delete_object(&key) {
+        Ok(Some(meta)) => Ok(DeletedObject {
+            key: Some(key),
+            version_id: version_id_string(meta.version_id.as_deref()),
+            delete_marker: if meta.is_delete_marker { Some(true) } else { None },
+            ..Default::default()
+        }),
+        Ok(None) => Ok(DeletedObject {
+            key: Some(key),
+            ..Default::default()
+        }),
+        Err(e) => Err(s3s::dto::Error {
+            code: Some("InternalError".to_owned()),
+            key: Some(key),
+            message: Some(e.to_string()),
+            version_id: None,
+        }),
+    }
+}
+
+/// Build version/delete-marker lists from storage version entries.
+pub(crate) fn build_version_lists(
+    entries: Vec<VersionEntry>,
+) -> (Vec<ObjectVersion>, Vec<DeleteMarkerEntry>) {
+    let mut versions = Vec::new();
+    let mut delete_markers = Vec::new();
+
+    for entry in entries {
+        let last_modified =
+            Timestamp::from(UNIX_EPOCH + Duration::from_secs(entry.meta.last_modified));
+
+        if entry.meta.is_delete_marker {
+            delete_markers.push(DeleteMarkerEntry {
+                is_latest: Some(entry.is_latest),
+                key: Some(entry.key),
+                last_modified: Some(last_modified),
+                version_id: Some(entry.version_id),
+                ..Default::default()
+            });
+        } else {
+            let size = entry.meta.data_length().cast_signed();
+            versions.push(ObjectVersion {
+                e_tag: Some(ETag::Strong(entry.meta.etag)),
+                is_latest: Some(entry.is_latest),
+                key: Some(entry.key),
+                last_modified: Some(last_modified),
+                size: Some(size),
+                version_id: Some(entry.version_id),
+                ..Default::default()
+            });
+        }
+    }
+
+    (versions, delete_markers)
+}
+
+/// Resolve an object by key, optionally looking up a specific version.
+/// Uses a single read transaction to avoid TOCTOU between tables.
+/// Returns the meta or an `io::Error` with appropriate `ErrorKind`.
+pub(crate) fn resolve_object_version(
+    store: &BucketStore,
+    key: &str,
+    version_id: Option<&str>,
+) -> io::Result<ObjectMeta> {
+    let not_found_msg = if version_id.is_some() { "NoSuchVersion" } else { "NoSuchKey" };
+    let meta = store
+        .get_object_or_version(key, version_id)?
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, not_found_msg))?;
+
+    if meta.is_delete_marker {
+        return Err(io::Error::new(io::ErrorKind::NotFound, "DeleteMarker"));
+    }
+
+    Ok(meta)
+}
+
+/// Execute copy-object blocking operation: resolve source, copy to tmp, put in destination.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn execute_copy_blocking(
+    src_store: &BucketStore,
+    dest_store: &BucketStore,
+    src_key: &str,
+    src_version_id: Option<&str>,
+    dest_key: &str,
+    tmp_path: &std::path::Path,
+    replace_metadata: bool,
+    req_content_type: Option<String>,
+    req_metadata: std::collections::HashMap<String, String>,
+    now: u64,
+    max_obj_size: u64,
+) -> io::Result<(String, ObjectMeta, Option<String>, u64)> {
+    let src_meta = resolve_object_version(src_store, src_key, src_version_id)?;
+
+    if max_obj_size > 0 && src_meta.data_length() > max_obj_size {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "EntityTooLarge: source object exceeds max_object_size",
+        ));
+    }
+
+    let (content_type, user_metadata) = if replace_metadata {
+        (req_content_type, req_metadata)
+    } else {
+        (src_meta.content_type.clone(), src_meta.user_metadata.clone())
+    };
+
+    let (etag_hex, crc) = src_store.copy_to_tmp_file(&src_meta, tmp_path)?;
+    let data_len = src_meta.data_length();
+    let src_vid = src_meta.version_id;
+    match dest_store.put_object_streamed(
+        dest_key, tmp_path, content_type, etag_hex.clone(), now, user_metadata, Some(crc),
+    ) {
+        Ok(m) => Ok((etag_hex, m, src_vid, data_len)),
+        Err(e) => {
+            std::fs::remove_file(tmp_path).ok();
+            Err(e)
+        }
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,12 +1,14 @@
 mod compaction;
 mod multipart;
+mod segment;
 mod verify;
 pub mod versioning;
 
+pub use verify::VerifyResult;
+
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::os::unix::fs::FileExt;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -15,6 +17,10 @@ use redb::{Database, ReadableDatabase, ReadableTable, ReadableTableMetadata, Tab
 
 use crate::types::ObjectMeta;
 
+// Re-export from segment module for sibling modules and public API.
+pub use segment::SegmentStat;
+use segment::{ActiveWriter, COPY_BUF_SIZE, cleanup_temp_files, discover_segments, segment_filename};
+
 /// Result of listing objects: (objects, `common_prefixes`, truncated).
 pub type ListResult = (Vec<(String, ObjectMeta)>, Vec<String>, bool);
 
@@ -22,100 +28,20 @@ const OBJECTS: TableDefinition<&str, &[u8]> = TableDefinition::new("objects");
 const SEG_DEAD: TableDefinition<u32, u64> = TableDefinition::new("seg_dead");
 const SEG_COMPACTING: TableDefinition<u32, u8> = TableDefinition::new("seg_compacting");
 
-const COPY_BUF_SIZE: usize = 8 * 1024 * 1024; // 8 MB
 const DEFAULT_MAX_SEGMENT_SIZE: u64 = 4 * 1024 * 1024 * 1024; // 4 GB
-
-/// Copy with 8 MB buffer — reduces syscalls for large files.
-fn copy_large(reader: &mut impl Read, writer: &mut impl Write) -> io::Result<u64> {
-    let mut buf = vec![0u8; COPY_BUF_SIZE];
-    let mut total = 0u64;
-    loop {
-        let n = reader.read(&mut buf)?;
-        if n == 0 {
-            return Ok(total);
-        }
-        writer.write_all(&buf[..n])?;
-        #[allow(clippy::cast_possible_truncation)]
-        {
-            total += n as u64;
-        }
-    }
-}
-
-fn segment_filename(id: u32) -> String {
-    format!("seg_{id:06}.bin")
-}
-
-pub struct SegmentStat {
-    pub id: u32,
-    pub size: u64,
-    pub dead_bytes: u64,
-}
-
-// === Per-segment locking ===
-//
-// Locking strategy:
-//   writer: Mutex<ActiveWriter>     — serializes appends + rotation to the active segment
-//   segments: RwLock<HashMap<u32, Arc<RwLock<File>>>>
-//     outer RwLock  — structural changes (add/remove segments during rotation/compaction)
-//     inner RwLock  — per-segment: read lock for concurrent pread, write lock for compaction swap
-//
-// Lock ordering: writer → segments(outer) → segments(inner per-seg)
-//
-// Reads from different segments never contend. Reads from the same segment are concurrent (shared lock).
-// Writes only block other writes (via Mutex), never block reads.
-// Compaction write-locks only the segment being compacted; all other segments remain readable.
-
-struct ActiveWriter {
-    id: u32,
-    file: File,
-    size: u64,
-}
-
-fn discover_segments(bucket_dir: &Path) -> io::Result<Vec<u32>> {
-    let mut ids = Vec::new();
-    for entry in fs::read_dir(bucket_dir)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else { continue };
-        if let Some(rest) = name.strip_prefix("seg_")
-            && let Some(num_str) = rest.strip_suffix(".bin")
-                && let Ok(id) = num_str.parse::<u32>() {
-                    ids.push(id);
-                }
-    }
-    ids.sort_unstable();
-    Ok(ids)
-}
-
-/// Remove leftover temp files from interrupted operations.
-fn cleanup_temp_files(bucket_dir: &Path) -> io::Result<()> {
-    for entry in fs::read_dir(bucket_dir)? {
-        let p = entry?.path();
-        if let Some(name) = p.file_name().and_then(|n| n.to_str())
-            && (name.starts_with(".tmp_")
-                || name.starts_with(".mpu_")
-                || name.ends_with(".bin.tmp")
-                || name == "data.bin.tmp")
-        {
-            fs::remove_file(&p).ok();
-        }
-    }
-    Ok(())
-}
 
 // === BucketStore ===
 
 pub struct BucketStore {
-    db: Database,
+    pub(super) db: Database,
     /// Serializes appends and rotation on the active segment.
-    writer: Mutex<ActiveWriter>,
+    pub(super) writer: Mutex<ActiveWriter>,
     /// Per-segment read handles.
     /// Outer `RwLock`: structural mutations (add/remove segments).
     /// Inner `RwLock<File>`: read lock for concurrent `pread`, write lock for compaction swap.
-    segments: RwLock<HashMap<u32, Arc<RwLock<File>>>>,
-    bucket_dir: PathBuf,
-    max_segment_size: u64,
+    pub(super) segments: RwLock<HashMap<u32, Arc<RwLock<File>>>>,
+    pub(super) bucket_dir: PathBuf,
+    pub(super) max_segment_size: u64,
 }
 
 #[allow(clippy::missing_errors_doc)]
@@ -188,329 +114,6 @@ impl BucketStore {
         Ok(store)
     }
 
-    // === Segment management ===
-
-    fn rotate_segment(&self, w: &mut ActiveWriter) -> io::Result<()> {
-        w.file.sync_all()?;
-        let new_id = w.id + 1;
-        let path = self.bucket_dir.join(segment_filename(new_id));
-        let new_file = OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(&path)?;
-
-        // Add read handle for the new segment
-        let reader = new_file.try_clone()?;
-        let mut map = self
-            .segments
-            .write()
-            .map_err(|_| io::Error::other("segments lock poisoned"))?;
-        map.insert(new_id, Arc::new(RwLock::new(reader)));
-        drop(map);
-
-        w.file = new_file;
-        w.size = 0;
-        w.id = new_id;
-        Ok(())
-    }
-
-    fn remove_segment(&self, segment_id: u32) -> io::Result<()> {
-        {
-            let mut map = self
-                .segments
-                .write()
-                .map_err(|_| io::Error::other("segments lock poisoned"))?;
-            map.remove(&segment_id);
-        }
-
-        let seg_path = self.bucket_dir.join(segment_filename(segment_id));
-        if seg_path.exists() {
-            fs::remove_file(&seg_path)?;
-        }
-
-        let txn = self.db.begin_write().map_err(io::Error::other)?;
-        {
-            let mut t = txn.open_table(SEG_DEAD).map_err(io::Error::other)?;
-            t.remove(segment_id).map_err(io::Error::other)?;
-        }
-        {
-            let mut t = txn.open_table(SEG_COMPACTING).map_err(io::Error::other)?;
-            t.remove(segment_id).map_err(io::Error::other)?;
-        }
-        txn.commit().map_err(io::Error::other)?;
-        Ok(())
-    }
-
-    fn get_segment_handle(&self, segment_id: u32) -> io::Result<Arc<RwLock<File>>> {
-        let seg = Arc::clone(
-            self.segments
-                .read()
-                .map_err(|_| io::Error::other("segments lock poisoned"))?
-                .get(&segment_id)
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::NotFound,
-                        format!("segment {segment_id} not found"),
-                    )
-                })?,
-        );
-        Ok(seg)
-    }
-
-    // === Recovery ===
-
-    fn truncate_orphans(&self) -> io::Result<()> {
-        let mut w = self
-            .writer
-            .lock()
-            .map_err(|_| io::Error::other("writer lock poisoned"))?;
-        let active_id = w.id;
-
-        let mut max_end: u64 = 0;
-        {
-            let txn = self.db.begin_read().map_err(io::Error::other)?;
-
-            // Scan objects table
-            let table = txn.open_table(OBJECTS).map_err(io::Error::other)?;
-            for result in table.iter().map_err(io::Error::other)? {
-                let (_k, v) = result.map_err(io::Error::other)?;
-                let obj = ObjectMeta::from_bytes(v.value()).map_err(io::Error::other)?;
-                if obj.segment_id == active_id {
-                    max_end = max_end.max(obj.offset + obj.length);
-                }
-            }
-
-            // Scan versions table
-            let ver_table = txn
-                .open_table(versioning::VERSIONS)
-                .map_err(io::Error::other)?;
-            for result in ver_table.iter().map_err(io::Error::other)? {
-                let (_k, v) = result.map_err(io::Error::other)?;
-                let obj = ObjectMeta::from_bytes(v.value()).map_err(io::Error::other)?;
-                if obj.segment_id == active_id && !obj.is_delete_marker {
-                    max_end = max_end.max(obj.offset + obj.length);
-                }
-            }
-        }
-
-        let file_size = w.file.seek(SeekFrom::End(0))?;
-        if file_size > max_end {
-            w.file.set_len(max_end)?;
-            w.size = max_end;
-        }
-        drop(w);
-        Ok(())
-    }
-
-    // === Per-segment dead bytes tracking ===
-
-    fn seg_dead_bytes(&self, segment_id: u32) -> u64 {
-        let Ok(txn) = self.db.begin_read() else {
-            return 0;
-        };
-        let Ok(table) = txn.open_table(SEG_DEAD) else {
-            return 0;
-        };
-        table
-            .get(segment_id)
-            .ok()
-            .flatten()
-            .map_or(0, |g| g.value())
-    }
-
-    fn get_seg_compacting(&self, segment_id: u32) -> bool {
-        let Ok(txn) = self.db.begin_read() else {
-            return false;
-        };
-        let Ok(table) = txn.open_table(SEG_COMPACTING) else {
-            return false;
-        };
-        table
-            .get(segment_id)
-            .ok()
-            .flatten()
-            .is_some_and(|g| g.value() == 1)
-    }
-
-    fn set_seg_compacting(&self, segment_id: u32, val: bool) -> io::Result<()> {
-        let txn = self.db.begin_write().map_err(io::Error::other)?;
-        {
-            let mut t = txn.open_table(SEG_COMPACTING).map_err(io::Error::other)?;
-            t.insert(segment_id, u8::from(val)).map_err(io::Error::other)?;
-        }
-        txn.commit().map_err(io::Error::other)?;
-        Ok(())
-    }
-
-    /// Total dead bytes across all segments.
-    pub fn dead_bytes(&self) -> u64 {
-        let Ok(txn) = self.db.begin_read() else {
-            return 0;
-        };
-        let Ok(table) = txn.open_table(SEG_DEAD) else {
-            return 0;
-        };
-        let Ok(iter) = table.iter() else { return 0 };
-        iter.filter_map(Result::ok).map(|(_, v)| v.value()).sum()
-    }
-
-    /// Total size across all segments.
-    pub fn data_file_size(&self) -> io::Result<u64> {
-        let map = self
-            .segments
-            .read()
-            .map_err(|_| io::Error::other("segments lock poisoned"))?;
-        map.values().try_fold(0u64, |total, seg| {
-            let file = seg
-                .read()
-                .map_err(|_| io::Error::other("segment lock poisoned"))?;
-            Ok(total + file.metadata()?.len())
-        })
-    }
-
-    /// Per-segment stats for autovacuum.
-    pub fn segment_stats(&self) -> io::Result<Vec<SegmentStat>> {
-        let map = self
-            .segments
-            .read()
-            .map_err(|_| io::Error::other("segments lock poisoned"))?;
-        let mut stats = Vec::with_capacity(map.len());
-        for (&id, seg) in &*map {
-            let file = seg
-                .read()
-                .map_err(|_| io::Error::other("segment lock poisoned"))?;
-            let size = file.metadata()?.len();
-            drop(file);
-            stats.push(SegmentStat {
-                id,
-                size,
-                dead_bytes: self.seg_dead_bytes(id),
-            });
-        }
-        drop(map);
-        stats.sort_by_key(|s| s.id);
-        Ok(stats)
-    }
-
-    /// Fsync the active writer segment to disk.
-    pub fn sync_active_segment(&self) -> io::Result<()> {
-        let w = self
-            .writer
-            .lock()
-            .map_err(|_| io::Error::other("writer lock poisoned"))?;
-        w.file.sync_all()
-    }
-
-    // === Data operations ===
-
-    pub fn read_data(&self, segment_id: u32, offset: u64, length: u64) -> io::Result<Vec<u8>> {
-        let len = usize::try_from(length)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        let mut buf = vec![0u8; len];
-
-        let seg_arc = self.get_segment_handle(segment_id)?;
-        let file = seg_arc
-            .read()
-            .map_err(|_| io::Error::other("segment lock poisoned"))?;
-        file.read_exact_at(&mut buf, offset)?;
-        drop(file);
-
-        Ok(buf)
-    }
-
-    pub fn append_data(&self, data: &[u8]) -> io::Result<(u32, u64, u64, u32)> {
-        let crc = crc32c::crc32c(data);
-        let mut w = self
-            .writer
-            .lock()
-            .map_err(|_| io::Error::other("writer lock poisoned"))?;
-        #[allow(clippy::cast_possible_truncation)] // usize → u64 never truncates on 64-bit
-        let data_len = data.len() as u64;
-        let total_len = data_len + 4;
-
-        if w.size + total_len > self.max_segment_size && w.size > 0 {
-            self.rotate_segment(&mut w)?;
-        }
-
-        let segment_id = w.id;
-        let offset = w.file.seek(SeekFrom::End(0))?;
-        w.file.write_all(data)?;
-        w.file.write_all(&crc.to_le_bytes())?;
-        w.size = offset + total_len;
-        drop(w);
-        Ok((segment_id, offset, total_len, crc))
-    }
-
-    /// Read object data, validating the CRC32C checksum if present.
-    /// Returns only the data portion (without the 4-byte CRC trailer).
-    #[allow(clippy::cast_possible_truncation)] // segment sizes bounded well within usize on 64-bit
-    pub fn read_object(&self, meta: &ObjectMeta) -> io::Result<Vec<u8>> {
-        if let Some(expected_crc) = meta.content_crc32c {
-            if meta.length < 4 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "object length is smaller than the CRC trailer",
-                ));
-            }
-            let full = self.read_data(meta.segment_id, meta.offset, meta.length)?;
-            let data_len = meta.data_length() as usize;
-            let computed = crc32c::crc32c(&full[..data_len]);
-            let stored_crc = u32::from_le_bytes([
-                full[data_len],
-                full[data_len + 1],
-                full[data_len + 2],
-                full[data_len + 3],
-            ]);
-            if computed != expected_crc || stored_crc != expected_crc {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "CRC32C mismatch: expected {expected_crc:#010x}, \
-                         stored {stored_crc:#010x}, computed {computed:#010x}"
-                    ),
-                ));
-            }
-            let mut data = full;
-            data.truncate(data_len);
-            Ok(data)
-        } else {
-            self.read_data(meta.segment_id, meta.offset, meta.length)
-        }
-    }
-
-    /// Copy object data from a source segment to a temp file in 256 KB chunks,
-    /// computing MD5 and CRC32C incrementally. Returns `(md5_hex, crc32c)`.
-    /// Cleans up the temp file on any error.
-    pub fn copy_to_tmp_file(&self, meta: &ObjectMeta, tmp_path: &Path) -> io::Result<(String, u32)> {
-        use md5::{Digest, Md5};
-
-        let mut hasher = Md5::new();
-        let mut crc: u32 = 0;
-        let data_len = meta.data_length();
-        let result: io::Result<()> = (|| {
-            let file = File::create(tmp_path)?;
-            let mut writer = io::BufWriter::with_capacity(1024 * 1024, file);
-            let mut pos = 0u64;
-            while pos < data_len {
-                let chunk_size = (data_len - pos).min(256 * 1024);
-                let chunk = self.read_data(meta.segment_id, meta.offset + pos, chunk_size)?;
-                writer.write_all(&chunk)?;
-                hasher.update(&chunk);
-                crc = crc32c::crc32c_append(crc, &chunk);
-                pos += chunk_size;
-            }
-            writer.flush()?;
-            Ok(())
-        })();
-        if let Err(e) = result {
-            fs::remove_file(tmp_path).ok();
-            return Err(e);
-        }
-        Ok((format!("{:x}", hasher.finalize()), crc))
-    }
-
     pub fn put_meta(&self, key: &str, meta: &mut ObjectMeta) -> io::Result<()> {
         self.commit_put(key, meta)
     }
@@ -536,51 +139,6 @@ impl BucketStore {
 
     pub fn bucket_dir(&self) -> &Path {
         &self.bucket_dir
-    }
-
-    // === Streamed PUT ===
-
-    /// Write tmp file data into the active segment — rename if empty, copy otherwise.
-    /// If `content_crc32c` is provided, appends a 4-byte LE CRC after the data.
-    fn write_to_segment(
-        &self,
-        w: &mut ActiveWriter,
-        tmp_path: &Path,
-        mut tmp: File,
-        tmp_size: u64,
-        content_crc32c: Option<u32>,
-    ) -> io::Result<(u64, u64)> {
-        let crc_len = if content_crc32c.is_some() { 4u64 } else { 0 };
-        let seg_path = self.bucket_dir.join(segment_filename(w.id));
-        if w.size == 0 {
-            // Empty segment — rename tmp file to become the segment (O(1) vs O(n) copy)
-            drop(tmp);
-            fs::rename(tmp_path, &seg_path)?;
-            w.file = OpenOptions::new().read(true).write(true).open(&seg_path)?;
-            if let Some(crc) = content_crc32c {
-                w.file.seek(SeekFrom::End(0))?;
-                w.file.write_all(&crc.to_le_bytes())?;
-            }
-            w.file.sync_all()?;
-            let total = tmp_size + crc_len;
-            w.size = total;
-            let reader = w.file.try_clone()?;
-            self.segments
-                .write()
-                .map_err(|_| io::Error::other("segments lock poisoned"))?
-                .insert(w.id, Arc::new(RwLock::new(reader)));
-            Ok((0, total))
-        } else {
-            let offset = w.file.seek(SeekFrom::End(0))?;
-            let data_length = copy_large(&mut tmp, &mut w.file)?;
-            if let Some(crc) = content_crc32c {
-                w.file.write_all(&crc.to_le_bytes())?;
-            }
-            w.file.sync_all()?;
-            let total = data_length + crc_len;
-            w.size = offset + total;
-            Ok((offset, total))
-        }
     }
 
     #[allow(clippy::too_many_arguments)] // all fields required for atomic put; builder would complicate rollback

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -134,8 +134,10 @@ impl BucketStore {
         }
 
         let seg_path = self.bucket_dir.join(segment_filename(segment_id));
-        if seg_path.exists() {
-            fs::remove_file(&seg_path)?;
+        if let Err(e) = fs::remove_file(&seg_path)
+            && e.kind() != io::ErrorKind::NotFound
+        {
+            return Err(e);
         }
 
         let txn = self.db.begin_write().map_err(io::Error::other)?;

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -1,0 +1,466 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::os::unix::fs::FileExt;
+use std::path::Path;
+use std::sync::{Arc, RwLock};
+
+use redb::{ReadableDatabase, ReadableTable};
+
+use crate::types::ObjectMeta;
+
+use super::versioning;
+use super::{BucketStore, OBJECTS, SEG_COMPACTING, SEG_DEAD};
+
+pub(super) const COPY_BUF_SIZE: usize = 8 * 1024 * 1024; // 8 MB
+
+/// Copy with 8 MB buffer — reduces syscalls for large files.
+pub(super) fn copy_large(reader: &mut impl Read, writer: &mut impl Write) -> io::Result<u64> {
+    let mut buf = vec![0u8; COPY_BUF_SIZE];
+    let mut total = 0u64;
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            return Ok(total);
+        }
+        writer.write_all(&buf[..n])?;
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            total += n as u64;
+        }
+    }
+}
+
+pub(super) fn segment_filename(id: u32) -> String {
+    format!("seg_{id:06}.bin")
+}
+
+pub struct SegmentStat {
+    pub id: u32,
+    pub size: u64,
+    pub dead_bytes: u64,
+}
+
+// === Per-segment locking ===
+//
+// Locking strategy:
+//   writer: Mutex<ActiveWriter>     — serializes appends + rotation to the active segment
+//   segments: RwLock<HashMap<u32, Arc<RwLock<File>>>>
+//     outer RwLock  — structural changes (add/remove segments during rotation/compaction)
+//     inner RwLock  — per-segment: read lock for concurrent pread, write lock for compaction swap
+//
+// Lock ordering: writer → segments(outer) → segments(inner per-seg)
+//
+// Reads from different segments never contend. Reads from the same segment are concurrent (shared lock).
+// Writes only block other writes (via Mutex), never block reads.
+// Compaction write-locks only the segment being compacted; all other segments remain readable.
+
+pub struct ActiveWriter {
+    pub id: u32,
+    pub file: File,
+    pub size: u64,
+}
+
+pub(super) fn discover_segments(bucket_dir: &Path) -> io::Result<Vec<u32>> {
+    let mut ids = Vec::new();
+    for entry in fs::read_dir(bucket_dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if let Some(rest) = name.strip_prefix("seg_")
+            && let Some(num_str) = rest.strip_suffix(".bin")
+                && let Ok(id) = num_str.parse::<u32>() {
+                    ids.push(id);
+                }
+    }
+    ids.sort_unstable();
+    Ok(ids)
+}
+
+/// Remove leftover temp files from interrupted operations.
+pub(super) fn cleanup_temp_files(bucket_dir: &Path) -> io::Result<()> {
+    for entry in fs::read_dir(bucket_dir)? {
+        let p = entry?.path();
+        if let Some(name) = p.file_name().and_then(|n| n.to_str())
+            && (name.starts_with(".tmp_")
+                || name.starts_with(".mpu_")
+                || name.ends_with(".bin.tmp")
+                || name == "data.bin.tmp")
+        {
+            fs::remove_file(&p).ok();
+        }
+    }
+    Ok(())
+}
+
+// === BucketStore segment I/O ===
+
+#[allow(clippy::missing_errors_doc)]
+impl BucketStore {
+    // === Segment management ===
+
+    pub(super) fn rotate_segment(&self, w: &mut ActiveWriter) -> io::Result<()> {
+        w.file.sync_all()?;
+        let new_id = w.id + 1;
+        let path = self.bucket_dir.join(segment_filename(new_id));
+        let new_file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)?;
+
+        // Add read handle for the new segment
+        let reader = new_file.try_clone()?;
+        let mut map = self
+            .segments
+            .write()
+            .map_err(|_| io::Error::other("segments lock poisoned"))?;
+        map.insert(new_id, Arc::new(RwLock::new(reader)));
+        drop(map);
+
+        w.file = new_file;
+        w.size = 0;
+        w.id = new_id;
+        Ok(())
+    }
+
+    pub(super) fn remove_segment(&self, segment_id: u32) -> io::Result<()> {
+        {
+            let mut map = self
+                .segments
+                .write()
+                .map_err(|_| io::Error::other("segments lock poisoned"))?;
+            map.remove(&segment_id);
+        }
+
+        let seg_path = self.bucket_dir.join(segment_filename(segment_id));
+        if seg_path.exists() {
+            fs::remove_file(&seg_path)?;
+        }
+
+        let txn = self.db.begin_write().map_err(io::Error::other)?;
+        {
+            let mut t = txn.open_table(SEG_DEAD).map_err(io::Error::other)?;
+            t.remove(segment_id).map_err(io::Error::other)?;
+        }
+        {
+            let mut t = txn.open_table(SEG_COMPACTING).map_err(io::Error::other)?;
+            t.remove(segment_id).map_err(io::Error::other)?;
+        }
+        txn.commit().map_err(io::Error::other)?;
+        Ok(())
+    }
+
+    pub(super) fn get_segment_handle(&self, segment_id: u32) -> io::Result<Arc<RwLock<File>>> {
+        let seg = Arc::clone(
+            self.segments
+                .read()
+                .map_err(|_| io::Error::other("segments lock poisoned"))?
+                .get(&segment_id)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!("segment {segment_id} not found"),
+                    )
+                })?,
+        );
+        Ok(seg)
+    }
+
+    // === Recovery ===
+
+    pub(super) fn truncate_orphans(&self) -> io::Result<()> {
+        let mut w = self
+            .writer
+            .lock()
+            .map_err(|_| io::Error::other("writer lock poisoned"))?;
+        let active_id = w.id;
+
+        let mut max_end: u64 = 0;
+        {
+            let txn = self.db.begin_read().map_err(io::Error::other)?;
+
+            // Scan objects table
+            let table = txn.open_table(OBJECTS).map_err(io::Error::other)?;
+            for result in table.iter().map_err(io::Error::other)? {
+                let (_k, v) = result.map_err(io::Error::other)?;
+                let obj = ObjectMeta::from_bytes(v.value()).map_err(io::Error::other)?;
+                if obj.segment_id == active_id {
+                    max_end = max_end.max(obj.offset + obj.length);
+                }
+            }
+
+            // Scan versions table
+            let ver_table = txn
+                .open_table(versioning::VERSIONS)
+                .map_err(io::Error::other)?;
+            for result in ver_table.iter().map_err(io::Error::other)? {
+                let (_k, v) = result.map_err(io::Error::other)?;
+                let obj = ObjectMeta::from_bytes(v.value()).map_err(io::Error::other)?;
+                if obj.segment_id == active_id && !obj.is_delete_marker {
+                    max_end = max_end.max(obj.offset + obj.length);
+                }
+            }
+        }
+
+        let file_size = w.file.seek(SeekFrom::End(0))?;
+        if file_size > max_end {
+            w.file.set_len(max_end)?;
+            w.size = max_end;
+        }
+        drop(w);
+        Ok(())
+    }
+
+    // === Per-segment dead bytes tracking ===
+
+    pub(super) fn seg_dead_bytes(&self, segment_id: u32) -> u64 {
+        let Ok(txn) = self.db.begin_read() else {
+            return 0;
+        };
+        let Ok(table) = txn.open_table(SEG_DEAD) else {
+            return 0;
+        };
+        table
+            .get(segment_id)
+            .ok()
+            .flatten()
+            .map_or(0, |g| g.value())
+    }
+
+    pub(super) fn get_seg_compacting(&self, segment_id: u32) -> bool {
+        let Ok(txn) = self.db.begin_read() else {
+            return false;
+        };
+        let Ok(table) = txn.open_table(SEG_COMPACTING) else {
+            return false;
+        };
+        table
+            .get(segment_id)
+            .ok()
+            .flatten()
+            .is_some_and(|g| g.value() == 1)
+    }
+
+    pub(super) fn set_seg_compacting(&self, segment_id: u32, val: bool) -> io::Result<()> {
+        let txn = self.db.begin_write().map_err(io::Error::other)?;
+        {
+            let mut t = txn.open_table(SEG_COMPACTING).map_err(io::Error::other)?;
+            t.insert(segment_id, u8::from(val)).map_err(io::Error::other)?;
+        }
+        txn.commit().map_err(io::Error::other)?;
+        Ok(())
+    }
+
+    /// Total dead bytes across all segments.
+    pub fn dead_bytes(&self) -> u64 {
+        let Ok(txn) = self.db.begin_read() else {
+            return 0;
+        };
+        let Ok(table) = txn.open_table(SEG_DEAD) else {
+            return 0;
+        };
+        let Ok(iter) = table.iter() else { return 0 };
+        iter.filter_map(Result::ok).map(|(_, v)| v.value()).sum()
+    }
+
+    /// Total size across all segments.
+    pub fn data_file_size(&self) -> io::Result<u64> {
+        let map = self
+            .segments
+            .read()
+            .map_err(|_| io::Error::other("segments lock poisoned"))?;
+        map.values().try_fold(0u64, |total, seg| {
+            let file = seg
+                .read()
+                .map_err(|_| io::Error::other("segment lock poisoned"))?;
+            Ok(total + file.metadata()?.len())
+        })
+    }
+
+    /// Per-segment stats for autovacuum.
+    pub fn segment_stats(&self) -> io::Result<Vec<SegmentStat>> {
+        let map = self
+            .segments
+            .read()
+            .map_err(|_| io::Error::other("segments lock poisoned"))?;
+        let mut stats = Vec::with_capacity(map.len());
+        for (&id, seg) in &*map {
+            let file = seg
+                .read()
+                .map_err(|_| io::Error::other("segment lock poisoned"))?;
+            let size = file.metadata()?.len();
+            drop(file);
+            stats.push(SegmentStat {
+                id,
+                size,
+                dead_bytes: self.seg_dead_bytes(id),
+            });
+        }
+        drop(map);
+        stats.sort_by_key(|s| s.id);
+        Ok(stats)
+    }
+
+    /// Fsync the active writer segment to disk.
+    pub fn sync_active_segment(&self) -> io::Result<()> {
+        let w = self
+            .writer
+            .lock()
+            .map_err(|_| io::Error::other("writer lock poisoned"))?;
+        w.file.sync_all()
+    }
+
+    // === Data operations ===
+
+    pub fn read_data(&self, segment_id: u32, offset: u64, length: u64) -> io::Result<Vec<u8>> {
+        let len = usize::try_from(length)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let mut buf = vec![0u8; len];
+
+        let seg_arc = self.get_segment_handle(segment_id)?;
+        let file = seg_arc
+            .read()
+            .map_err(|_| io::Error::other("segment lock poisoned"))?;
+        file.read_exact_at(&mut buf, offset)?;
+        drop(file);
+
+        Ok(buf)
+    }
+
+    pub fn append_data(&self, data: &[u8]) -> io::Result<(u32, u64, u64, u32)> {
+        let crc = crc32c::crc32c(data);
+        let mut w = self
+            .writer
+            .lock()
+            .map_err(|_| io::Error::other("writer lock poisoned"))?;
+        #[allow(clippy::cast_possible_truncation)] // usize → u64 never truncates on 64-bit
+        let data_len = data.len() as u64;
+        let total_len = data_len + 4;
+
+        if w.size + total_len > self.max_segment_size && w.size > 0 {
+            self.rotate_segment(&mut w)?;
+        }
+
+        let segment_id = w.id;
+        let offset = w.file.seek(SeekFrom::End(0))?;
+        w.file.write_all(data)?;
+        w.file.write_all(&crc.to_le_bytes())?;
+        w.size = offset + total_len;
+        drop(w);
+        Ok((segment_id, offset, total_len, crc))
+    }
+
+    /// Read object data, validating the CRC32C checksum if present.
+    /// Returns only the data portion (without the 4-byte CRC trailer).
+    #[allow(clippy::cast_possible_truncation)] // segment sizes bounded well within usize on 64-bit
+    pub fn read_object(&self, meta: &ObjectMeta) -> io::Result<Vec<u8>> {
+        if let Some(expected_crc) = meta.content_crc32c {
+            if meta.length < 4 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "object length is smaller than the CRC trailer",
+                ));
+            }
+            let full = self.read_data(meta.segment_id, meta.offset, meta.length)?;
+            let data_len = meta.data_length() as usize;
+            let computed = crc32c::crc32c(&full[..data_len]);
+            let stored_crc = u32::from_le_bytes([
+                full[data_len],
+                full[data_len + 1],
+                full[data_len + 2],
+                full[data_len + 3],
+            ]);
+            if computed != expected_crc || stored_crc != expected_crc {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "CRC32C mismatch: expected {expected_crc:#010x}, \
+                         stored {stored_crc:#010x}, computed {computed:#010x}"
+                    ),
+                ));
+            }
+            let mut data = full;
+            data.truncate(data_len);
+            Ok(data)
+        } else {
+            self.read_data(meta.segment_id, meta.offset, meta.length)
+        }
+    }
+
+    /// Copy object data from a source segment to a temp file in 256 KB chunks,
+    /// computing MD5 and CRC32C incrementally. Returns `(md5_hex, crc32c)`.
+    /// Cleans up the temp file on any error.
+    pub fn copy_to_tmp_file(&self, meta: &ObjectMeta, tmp_path: &Path) -> io::Result<(String, u32)> {
+        use md5::{Digest, Md5};
+
+        let mut hasher = Md5::new();
+        let mut crc: u32 = 0;
+        let data_len = meta.data_length();
+        let result: io::Result<()> = (|| {
+            let file = File::create(tmp_path)?;
+            let mut writer = io::BufWriter::with_capacity(1024 * 1024, file);
+            let mut pos = 0u64;
+            while pos < data_len {
+                let chunk_size = (data_len - pos).min(256 * 1024);
+                let chunk = self.read_data(meta.segment_id, meta.offset + pos, chunk_size)?;
+                writer.write_all(&chunk)?;
+                hasher.update(&chunk);
+                crc = crc32c::crc32c_append(crc, &chunk);
+                pos += chunk_size;
+            }
+            writer.flush()?;
+            Ok(())
+        })();
+        if let Err(e) = result {
+            fs::remove_file(tmp_path).ok();
+            return Err(e);
+        }
+        Ok((format!("{:x}", hasher.finalize()), crc))
+    }
+
+    // === Streamed PUT ===
+
+    /// Write tmp file data into the active segment — rename if empty, copy otherwise.
+    /// If `content_crc32c` is provided, appends a 4-byte LE CRC after the data.
+    pub(super) fn write_to_segment(
+        &self,
+        w: &mut ActiveWriter,
+        tmp_path: &Path,
+        mut tmp: File,
+        tmp_size: u64,
+        content_crc32c: Option<u32>,
+    ) -> io::Result<(u64, u64)> {
+        let crc_len = if content_crc32c.is_some() { 4u64 } else { 0 };
+        let seg_path = self.bucket_dir.join(segment_filename(w.id));
+        if w.size == 0 {
+            // Empty segment — rename tmp file to become the segment (O(1) vs O(n) copy)
+            drop(tmp);
+            fs::rename(tmp_path, &seg_path)?;
+            w.file = OpenOptions::new().read(true).write(true).open(&seg_path)?;
+            if let Some(crc) = content_crc32c {
+                w.file.seek(SeekFrom::End(0))?;
+                w.file.write_all(&crc.to_le_bytes())?;
+            }
+            w.file.sync_all()?;
+            let total = tmp_size + crc_len;
+            w.size = total;
+            let reader = w.file.try_clone()?;
+            self.segments
+                .write()
+                .map_err(|_| io::Error::other("segments lock poisoned"))?
+                .insert(w.id, Arc::new(RwLock::new(reader)));
+            Ok((0, total))
+        } else {
+            let offset = w.file.seek(SeekFrom::End(0))?;
+            let data_length = copy_large(&mut tmp, &mut w.file)?;
+            if let Some(crc) = content_crc32c {
+                w.file.write_all(&crc.to_le_bytes())?;
+            }
+            w.file.sync_all()?;
+            let total = data_length + crc_len;
+            w.size = offset + total;
+            Ok((offset, total))
+        }
+    }
+}

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -55,9 +55,9 @@ pub struct SegmentStat {
 // Compaction write-locks only the segment being compacted; all other segments remain readable.
 
 pub struct ActiveWriter {
-    pub id: u32,
-    pub file: File,
-    pub size: u64,
+    pub(super) id: u32,
+    pub(super) file: File,
+    pub(super) size: u64,
 }
 
 pub(super) fn discover_segments(bucket_dir: &Path) -> io::Result<Vec<u32>> {
@@ -94,7 +94,7 @@ pub(super) fn cleanup_temp_files(bucket_dir: &Path) -> io::Result<()> {
 
 // === BucketStore segment I/O ===
 
-#[allow(clippy::missing_errors_doc)]
+#[allow(clippy::missing_errors_doc)] // internal segment I/O — error conditions are self-evident from io::Result
 impl BucketStore {
     // === Segment management ===
 

--- a/tests/head_bucket_test.rs
+++ b/tests/head_bucket_test.rs
@@ -1,4 +1,5 @@
 mod common;
+use aws_sdk_s3::error::SdkError;
 use common::{make_client, start_server};
 
 #[tokio::test]
@@ -52,4 +53,32 @@ async fn test_head_bucket_after_delete() {
         err.into_service_error().is_not_found(),
         "expected NotFound error"
     );
+}
+
+#[tokio::test]
+async fn test_head_bucket_auth_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let srv = start_server(dir.path()).await;
+    let client = make_client(srv.port, &srv.access_key, &srv.secret_key);
+
+    client.create_bucket().bucket("test").send().await.unwrap();
+
+    // Create non-admin key with no policies (no permissions at all)
+    let restricted = srv.auth_store.create_key("no-perms", false).unwrap();
+    let bad_client = make_client(srv.port, &restricted.access_key_id, &restricted.secret_key);
+
+    let err = bad_client
+        .head_bucket()
+        .bucket("test")
+        .send()
+        .await
+        .expect_err("head_bucket should fail with insufficient permissions");
+
+    // HeadBucket returns 403 for auth failures (no XML body, so check HTTP status)
+    let status = match &err {
+        SdkError::ServiceError(e) => e.raw().status().as_u16(),
+        SdkError::ResponseError(e) => e.raw().status().as_u16(),
+        other => panic!("unexpected error variant: {other:?}"),
+    };
+    assert_eq!(status, 403, "expected 403 Forbidden, got {status}");
 }

--- a/tests/s3_compat/ceph.rs
+++ b/tests/s3_compat/ceph.rs
@@ -48,8 +48,8 @@ secret_key = {alt_secret}
 display_name = Tenant
 user_id = tenant
 email = tenant@example.com
-access_key = {main_key}
-secret_key = {main_secret}
+access_key = {alt_key}
+secret_key = {alt_secret}
 "#
     )
 }


### PR DESCRIPTION
## Summary

Addresses all 8 subtasks from SIMPLE-28 (Phase 3 code health audit from PR review comments #33-#46):

- **SIMPLE-35**: Split 4 files below 800-line guideline (`s3impl.rs` 988→798, `grpc.rs` 991→798, `storage/mod.rs` 882→440, `serve.rs` 838→778)
- **SIMPLE-36**: Extract `run()` phases into `spawn_background_tasks`, `validate_metrics_auth`, `graceful_shutdown`
- **SIMPLE-37**: Extract `delete_one_versioned`, `delete_one_unversioned`, `build_version_lists` helpers from long functions; remove `#[allow(clippy::too_many_lines)]`
- **SIMPLE-38**: Add `test_head_bucket_auth_failure` test (non-admin key with no permissions → 403)
- **SIMPLE-39**: Pin `minio/mint:edge` to SHA digest, `ceph/s3-tests` to commit `06e2c57`
- **SIMPLE-40**: Fix tenant credential reuse in ceph s3-tests config (use `alt_key`/`alt_secret`)
- **SIMPLE-41**: Pre-build tox virtualenv in ceph s3-tests Dockerfile
- **SIMPLE-42**: Clarify CRC32C conditionality in backup documentation

Also fixes pre-existing bench compilation errors (`append_data` 4-tuple, `put_meta(&mut)`).

## Test plan

- [x] `cargo build` — no compilation errors
- [x] `cargo lint` — clippy passes with pedantic + nursery
- [x] `cargo test` — all 24 tests pass
- [x] `cargo test --test head_bucket_test test_head_bucket_auth_failure` — new test passes
- [x] `cargo bench --no-run` — benchmarks compile
- [x] All 4 target files under 800 lines
- [x] No `#[allow(clippy::too_many_lines)]` in refactored areas