### PR TITLE
fix(ci): correct ceph s3-tests pytest path after upstream rename

### DIFF
--- a/tests/s3_compat/ceph.rs
+++ b/tests/s3_compat/ceph.rs
@@ -58,7 +58,7 @@ secret_key = {alt_secret}
 async fn run_pytest(container: &ContainerAsync<GenericImage>) -> String {
     let pytest_cmd = concat!(
         "cd /s3-tests && S3TEST_CONF=/s3-tests/s3tests.conf tox -e py -- ",
-        "s3tests_boto3/functional/test_s3.py ",
+        "s3tests/functional/test_s3.py ",
         "-m 'not encryption and not sse_s3 and not bucket_logging ",
         "and not fails_on_aws and not s3select and not storage_class ",
         "and not tagging and not object_lock' ",
@@ -170,10 +170,10 @@ async fn compat_ceph_s3_tests() {
         .find_map(|l| l.strip_prefix("EXIT:"))
         .and_then(|s| s.trim().parse::<i32>().ok())
         .expect("missing pytest EXIT marker in output");
-    assert!(
-        matches!(exit_code, 0 | 1),
-        "pytest execution failed (exit code {exit_code}); check container setup"
-    );
+    if !matches!(exit_code, 0 | 1) {
+        eprintln!("--- pytest output (exit code {exit_code}) ---\n{output}\n---");
+        panic!("pytest execution failed (exit code {exit_code}); check container setup");
+    }
 
     let report = build_ceph_report(&output);
     print!("{report}");


### PR DESCRIPTION
## Summary

- Fix `s3tests_boto3/functional/test_s3.py` → `s3tests/functional/test_s3.py` in ceph compat test. Upstream ceph/s3-tests renamed the directory back in Sep 2025 (ceph/s3-tests@73c3b98), causing pytest to collect zero tests (exit code 4) on every scheduled run (24 consecutive daily failures).
- Print pytest output to stderr before panicking on unexpected exit codes for better CI diagnostics.

## Test plan

- [x] `cargo build --test s3_compat` compiles
- [x] `cargo lint` passes
- [x] No remaining `s3tests_boto3` references in codebase
- [ ] CI `S3 Compat - Ceph s3-tests` workflow passes (requires manual trigger since it runs on schedule/dispatch only)